### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+        env:
+          PAGES_BASE: /claude_playground
+      - name: Assemble site
+        run: |
+          mkdir _site
+          for pkg in packages/*/; do
+            name=$(basename "$pkg")
+            if [ -d "$pkg/dist" ]; then
+              cp -r "$pkg/dist" "_site/$name"
+            fi
+          done
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.shared.js
+++ b/vite.shared.js
@@ -10,8 +10,14 @@ import { resolve } from "path";
  * @param {number} [options.port] - Dev server port (optional)
  */
 export function createGameConfig({ root, port }) {
+  const packageName = root.split("/").pop();
+  const base = process.env.PAGES_BASE
+    ? `${process.env.PAGES_BASE}/${packageName}/`
+    : "/";
+
   return defineConfig({
     root,
+    base,
     build: {
       outDir: resolve(root, "dist"),
       emptyOutDir: true,

--- a/vite.shared.js
+++ b/vite.shared.js
@@ -11,9 +11,9 @@ import { resolve } from "path";
  */
 export function createGameConfig({ root, port }) {
   const packageName = root.split("/").pop();
-  const base = process.env.PAGES_BASE
-    ? `${process.env.PAGES_BASE}/${packageName}/`
-    : "/";
+  // eslint-disable-next-line no-undef
+  const pagesBase = process.env.PAGES_BASE;
+  const base = pagesBase ? `${pagesBase}/${packageName}/` : "/";
 
   return defineConfig({
     root,


### PR DESCRIPTION
## Summary

- Adds a `deploy.yml` GitHub Actions workflow that builds all workspace packages and deploys the assembled site to GitHub Pages
- Updates `vite.shared.js` to support a `PAGES_BASE` env var for correct asset paths under the repo's Pages URL (no effect on local dev)

Closes #12

## Details

**Workflow (`deploy.yml`):**
- Triggers on push to `main` and manual `workflow_dispatch`
- Runs `npm run build` with `PAGES_BASE=/claude_playground`
- Assembles `_site/` with each package's `dist/` as a subdirectory (arcade-hub, bowling, etc.)
- Deploys via `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`

**After merge**, the site will be live at: `https://vi-o-al-ai.github.io/claude_playground/arcade-hub/`

## Setup required

Enable GitHub Pages in repo **Settings → Pages** with source set to **GitHub Actions**.

## Test plan

- [x] Verified `npm run build` succeeds with `PAGES_BASE` set
- [x] Verified assembled `_site/` contains all 9 packages
- [ ] After merge, confirm workflow runs and site deploys successfully

https://claude.ai/code/session_012PTzjTdLifoKc19p7z4yit