### PR TITLE
Integrate shared-ui components into Sudoku

### DIFF
--- a/games/sudoku/index.html
+++ b/games/sudoku/index.html
@@ -8,15 +8,12 @@
   </head>
   <body>
     <div id="app">
-      <header>
-        <h1>Sudoku</h1>
-        <div id="difficulty-selector">
-          <button class="diff-btn active" data-difficulty="easy">Easy</button>
-          <button class="diff-btn" data-difficulty="medium">Medium</button>
-          <button class="diff-btn" data-difficulty="hard">Hard</button>
-          <button class="diff-btn" data-difficulty="expert">Expert</button>
-        </div>
-      </header>
+      <div id="difficulty-selector">
+        <button class="diff-btn active" data-difficulty="easy">Easy</button>
+        <button class="diff-btn" data-difficulty="medium">Medium</button>
+        <button class="diff-btn" data-difficulty="hard">Hard</button>
+        <button class="diff-btn" data-difficulty="expert">Expert</button>
+      </div>
 
       <div id="game-area">
         <div id="game-info">
@@ -109,13 +106,6 @@
           <button id="btn-save">Save</button>
           <button id="btn-load">Resume</button>
           <button id="btn-share">Share</button>
-        </div>
-      </div>
-
-      <div id="modal-overlay" class="hidden">
-        <div id="modal">
-          <div id="modal-content"></div>
-          <div id="modal-actions"></div>
         </div>
       </div>
     </div>

--- a/games/sudoku/package.json
+++ b/games/sudoku/package.json
@@ -8,5 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "@arcade/shared-ui": "*"
   }
 }

--- a/games/sudoku/src/ui.js
+++ b/games/sudoku/src/ui.js
@@ -20,6 +20,7 @@ import {
   deserializeState,
   shareUrl,
 } from "./game-state.js";
+import { Modal, GameHeader, GameOver } from "@arcade/shared-ui";
 
 let state = createGameState("easy");
 let timerInterval = null;
@@ -29,8 +30,16 @@ const timerEl = document.getElementById("timer");
 const mistakesEl = document.getElementById("mistakes-counter");
 const hintCountEl = document.getElementById("hint-count");
 
+const modal = new Modal();
+const gameOverOverlay = new GameOver();
+
 // --- Initialize ---
 function init() {
+  new GameHeader({
+    title: "Sudoku",
+    container: document.getElementById("app"),
+  });
+
   checkSharedPuzzle();
   setupEventListeners();
   startNewGame();
@@ -283,71 +292,27 @@ function handleWin() {
   boardEl.classList.add("board-win");
   setTimeout(() => boardEl.classList.remove("board-win"), 1000);
 
-  showModal(
-    "Congratulations!",
-    `You solved the ${state.difficulty} puzzle in ${formatTime(state.timerSeconds)} with ${state.mistakes} mistake${state.mistakes !== 1 ? "s" : ""}.`,
-    [
-      {
-        text: "New Game",
-        class: "modal-btn-primary",
-        action: () => {
-          hideModal();
-          startNewGame();
-        },
-      },
-      {
-        text: "Share",
-        class: "modal-btn-secondary",
-        action: () => {
-          hideModal();
-          handleShare();
-        },
-      },
+  gameOverOverlay.show({
+    title: "Congratulations!",
+    stats: [
+      { label: "Time", value: formatTime(state.timerSeconds) },
+      { label: "Mistakes", value: String(state.mistakes) },
+      { label: "Difficulty", value: state.difficulty },
     ],
-  );
+    onRestart: () => startNewGame(),
+    restartLabel: "New Game",
+    extraButtons: [{ label: "Share", onClick: () => handleShare(), variant: "secondary" }],
+  });
 }
 
 function handleGameOver() {
   stopTimer();
-  showModal("Game Over", `You made ${state.maxMistakes} mistakes. Better luck next time!`, [
-    {
-      text: "Try Again",
-      class: "modal-btn-primary",
-      action: () => {
-        hideModal();
-        startNewGame();
-      },
-    },
-    { text: "Close", class: "modal-btn-secondary", action: hideModal },
-  ]);
-}
-
-// --- Modal ---
-
-function showModal(title, message, buttons) {
-  const overlay = document.getElementById("modal-overlay");
-  const content = document.getElementById("modal-content");
-  const actions = document.getElementById("modal-actions");
-
-  content.innerHTML = `<h2>${title}</h2><p>${message}</p>`;
-  actions.innerHTML = "";
-
-  buttons.forEach((b) => {
-    const btn = document.createElement("button");
-    btn.textContent = b.text;
-    btn.className = b.class;
-    btn.addEventListener("click", b.action);
-    actions.appendChild(btn);
+  gameOverOverlay.show({
+    title: "Game Over",
+    stats: [{ label: "Mistakes", value: `${state.maxMistakes} / ${state.maxMistakes}` }],
+    onRestart: () => startNewGame(),
+    restartLabel: "Try Again",
   });
-
-  overlay.classList.remove("hidden");
-  overlay.addEventListener("click", (e) => {
-    if (e.target === overlay) hideModal();
-  });
-}
-
-function hideModal() {
-  document.getElementById("modal-overlay").classList.add("hidden");
 }
 
 // --- Save / Load ---
@@ -355,17 +320,21 @@ function hideModal() {
 function handleSave() {
   const data = serializeState(state);
   localStorage.setItem("sudoku_save", JSON.stringify(data));
-  showModal("Game Saved", "Your progress has been saved. You can resume anytime.", [
-    { text: "OK", class: "modal-btn-primary", action: hideModal },
-  ]);
+  modal.show({
+    title: "Game Saved",
+    message: "Your progress has been saved. You can resume anytime.",
+    buttons: [{ label: "OK", variant: "primary" }],
+  });
 }
 
 function handleLoad() {
   const raw = localStorage.getItem("sudoku_save");
   if (!raw) {
-    showModal("No Saved Game", "There is no saved game to resume.", [
-      { text: "OK", class: "modal-btn-primary", action: hideModal },
-    ]);
+    modal.show({
+      title: "No Saved Game",
+      message: "There is no saved game to resume.",
+      buttons: [{ label: "OK", variant: "primary" }],
+    });
     return;
   }
 
@@ -380,13 +349,17 @@ function handleLoad() {
     } else {
       timerEl.textContent = formatTime(state.timerSeconds);
     }
-    showModal("Game Resumed", `Your ${state.difficulty} game has been loaded.`, [
-      { text: "OK", class: "modal-btn-primary", action: hideModal },
-    ]);
+    modal.show({
+      title: "Game Resumed",
+      message: `Your ${state.difficulty} game has been loaded.`,
+      buttons: [{ label: "OK", variant: "primary" }],
+    });
   } catch {
-    showModal("Error", "Could not load saved game. The save data may be corrupted.", [
-      { text: "OK", class: "modal-btn-primary", action: hideModal },
-    ]);
+    modal.show({
+      title: "Error",
+      message: "Could not load saved game. The save data may be corrupted.",
+      buttons: [{ label: "OK", variant: "primary" }],
+    });
   }
 }
 
@@ -394,43 +367,38 @@ function handleLoad() {
 
 function handleShare() {
   const url = shareUrl(state, `${window.location.origin}${window.location.pathname}`);
-  const overlay = document.getElementById("modal-overlay");
-  const content = document.getElementById("modal-content");
-  const actions = document.getElementById("modal-actions");
+  modal.show({
+    title: "Share Puzzle",
+    message: `<p>Share this ${state.difficulty} puzzle with friends:</p>
+      <div id="share-link-box">
+        <input type="text" id="share-url" value="${url}" readonly>
+        <button id="copy-btn">Copy</button>
+      </div>`,
+    buttons: [{ label: "Close", variant: "secondary" }],
+  });
 
-  content.innerHTML = `
-    <h2>Share Puzzle</h2>
-    <p>Share this ${state.difficulty} puzzle with friends:</p>
-    <div id="share-link-box">
-      <input type="text" id="share-url" value="${url}" readonly>
-      <button id="copy-btn">Copy</button>
-    </div>
-  `;
-  actions.innerHTML = `<button class="modal-btn-secondary" id="share-close">Close</button>`;
-  overlay.classList.remove("hidden");
-
-  document.getElementById("copy-btn").addEventListener("click", () => {
-    const input = document.getElementById("share-url");
-    input.select();
-    navigator.clipboard
-      .writeText(url)
-      .then(() => {
-        document.getElementById("copy-btn").textContent = "Copied!";
-        setTimeout(() => {
-          const btn = document.getElementById("copy-btn");
-          if (btn) btn.textContent = "Copy";
-        }, 2000);
-      })
-      .catch(() => {
-        document.execCommand("copy");
-        document.getElementById("copy-btn").textContent = "Copied!";
+  setTimeout(() => {
+    const copyBtn = document.getElementById("copy-btn");
+    if (copyBtn) {
+      copyBtn.addEventListener("click", () => {
+        const input = document.getElementById("share-url");
+        input.select();
+        navigator.clipboard
+          .writeText(url)
+          .then(() => {
+            document.getElementById("copy-btn").textContent = "Copied!";
+            setTimeout(() => {
+              const btn = document.getElementById("copy-btn");
+              if (btn) btn.textContent = "Copy";
+            }, 2000);
+          })
+          .catch(() => {
+            document.execCommand("copy");
+            document.getElementById("copy-btn").textContent = "Copied!";
+          });
       });
-  });
-
-  document.getElementById("share-close").addEventListener("click", hideModal);
-  overlay.addEventListener("click", (e) => {
-    if (e.target === overlay) hideModal();
-  });
+    }
+  }, 0);
 }
 
 // --- Start ---

--- a/games/sudoku/style.css
+++ b/games/sudoku/style.css
@@ -44,23 +44,11 @@ body {
   max-width: 500px;
 }
 
-header {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
-header h1 {
-  font-size: 28px;
-  font-weight: 700;
-  color: var(--primary-dark);
-  margin-bottom: 12px;
-  letter-spacing: -0.5px;
-}
-
 #difficulty-selector {
   display: flex;
   gap: 8px;
   justify-content: center;
+  margin-bottom: 16px;
 }
 
 .diff-btn {
@@ -377,125 +365,6 @@ header h1 {
 
 #btn-share:hover {
   opacity: 0.9;
-}
-
-/* Modal */
-#modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100;
-  backdrop-filter: blur(4px);
-}
-
-#modal-overlay.hidden {
-  display: none;
-}
-
-#modal {
-  background: var(--card);
-  border-radius: 16px;
-  padding: 32px;
-  max-width: 400px;
-  width: 90%;
-  text-align: center;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  animation: modalIn 0.3s ease;
-}
-
-@keyframes modalIn {
-  from {
-    transform: scale(0.9);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-#modal h2 {
-  font-size: 24px;
-  margin-bottom: 12px;
-}
-
-#modal p {
-  color: var(--text-light);
-  margin-bottom: 8px;
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-#modal-actions {
-  display: flex;
-  gap: 10px;
-  justify-content: center;
-  margin-top: 20px;
-}
-
-#modal-actions button {
-  padding: 10px 24px;
-  border: none;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.modal-btn-primary {
-  background: var(--primary);
-  color: white;
-}
-
-.modal-btn-primary:hover {
-  background: var(--primary-dark);
-}
-
-.modal-btn-secondary {
-  background: var(--bg);
-  color: var(--text);
-}
-
-.modal-btn-secondary:hover {
-  background: var(--border);
-}
-
-#share-link-box {
-  display: flex;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-#share-link-box input {
-  flex: 1;
-  padding: 8px 12px;
-  border: 2px solid var(--border);
-  border-radius: 8px;
-  font-size: 12px;
-  color: var(--text);
-  outline: none;
-}
-
-#share-link-box input:focus {
-  border-color: var(--primary);
-}
-
-#share-link-box button {
-  padding: 8px 16px;
-  background: var(--primary);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-weight: 600;
-  cursor: pointer;
-  font-size: 12px;
 }
 
 /* Win animation */

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,10 @@
     },
     "games/sudoku": {
       "name": "@ai-arcade/sudoku",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@arcade/shared-ui": "*"
+      }
     },
     "games/tic-tac-toe": {
       "name": "@ai-arcade/tic-tac-toe",


### PR DESCRIPTION
## Summary
- Replace custom modal system with `Modal` from `@arcade/shared-ui` for save/load/share dialogs
- Use `GameOver` overlay for win and game-over screens with stats display (time, mistakes, difficulty)
- Add `GameHeader` component for arcade navigation
- Remove ~170 lines of custom modal HTML/CSS/JS

Closes #23 (partial - Sudoku)

## Test plan
- [x] All 112 existing tests pass
- [ ] Verify modal dialogs (save, load, share) render correctly
- [ ] Verify win overlay shows time/mistakes/difficulty stats
- [ ] Verify game-over overlay with retry button works
- [ ] Verify GameHeader back link and title display

https://claude.ai/code/session_01PEzDo8iPoQjNJMqKUU4SdH