### PR TITLE
Integrate shared-ui components into Solitaire

### DIFF
--- a/games/solitaire/index.html
+++ b/games/solitaire/index.html
@@ -24,17 +24,12 @@
         padding: 16px;
       }
 
-      header {
+      #stats-bar {
         display: flex;
         justify-content: space-between;
         align-items: center;
         margin-bottom: 16px;
         color: #fff;
-      }
-
-      header h1 {
-        font-size: 1.4rem;
-        letter-spacing: 2px;
       }
 
       #stats {
@@ -187,31 +182,6 @@
         color: rgba(255, 255, 255, 0.5);
       }
 
-      /* Win overlay */
-      #win-overlay {
-        display: none;
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.6);
-        z-index: 2000;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
-        gap: 20px;
-        color: #fff;
-      }
-      #win-overlay.show {
-        display: flex;
-      }
-      #win-overlay h2 {
-        font-size: 3rem;
-        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-      }
-      #win-overlay p {
-        font-size: 1.1rem;
-        opacity: 0.85;
-      }
-
       @media (max-width: 720px) {
         :root {
           --cw: 72px;
@@ -253,8 +223,7 @@
   </head>
   <body>
     <div id="app">
-      <header>
-        <h1>SOLITAIRE</h1>
+      <div id="stats-bar">
         <div id="stats">
           Moves:
           <span id="move-count">0</span>
@@ -262,7 +231,7 @@
           <span id="timer">0:00</span>
         </div>
         <button class="btn" onclick="newGame()">New Game</button>
-      </header>
+      </div>
 
       <div id="top-row">
         <div class="pile-slot" id="stock"></div>
@@ -284,14 +253,6 @@
         <div class="tableau-col" id="t5"></div>
         <div class="tableau-col" id="t6"></div>
       </div>
-    </div>
-
-    <div id="win-overlay">
-      <h2>You Win!</h2>
-      <p id="win-stats"></p>
-      <button class="btn" style="font-size: 1rem; padding: 10px 28px" onclick="newGame()">
-        Play Again
-      </button>
     </div>
 
     <script type="module" src="./src/ui.js"></script>

--- a/games/solitaire/package.json
+++ b/games/solitaire/package.json
@@ -8,5 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "@arcade/shared-ui": "*"
   }
 }

--- a/games/solitaire/src/ui.js
+++ b/games/solitaire/src/ui.js
@@ -11,12 +11,21 @@ import {
   clickStock,
   checkWin,
 } from "./engine.js";
+import { GameHeader, GameOver } from "@arcade/shared-ui";
 
 let state = {};
 let moveCount = 0;
 let timerStart = null;
 let timerInterval = null;
 let dragInfo = null;
+
+const gameOverOverlay = new GameOver();
+
+// Add shared GameHeader
+new GameHeader({
+  title: "Solitaire",
+  container: document.getElementById("app"),
+});
 
 // ---- Game lifecycle ----
 
@@ -25,7 +34,7 @@ window.newGame = function () {
   moveCount = 0;
   document.getElementById("move-count").textContent = "0";
   document.getElementById("timer").textContent = "0:00";
-  document.getElementById("win-overlay").classList.remove("show");
+  gameOverOverlay.hide();
 
   state = createInitialState();
 
@@ -52,9 +61,21 @@ function handleWin() {
   const elapsed = Math.floor((Date.now() - timerStart) / 1000);
   const m = Math.floor(elapsed / 60);
   const s = elapsed % 60;
-  document.getElementById("win-stats").textContent =
-    `${moveCount} moves in ${m}:${s.toString().padStart(2, "0")}`;
-  setTimeout(() => document.getElementById("win-overlay").classList.add("show"), 400);
+  const timeStr = `${m}:${s.toString().padStart(2, "0")}`;
+
+  setTimeout(
+    () =>
+      gameOverOverlay.show({
+        title: "You Win!",
+        stats: [
+          { label: "Moves", value: String(moveCount) },
+          { label: "Time", value: timeStr },
+        ],
+        onRestart: () => window.newGame(),
+        restartLabel: "Play Again",
+      }),
+    400,
+  );
 }
 
 // ---- Render ----

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,10 @@
     },
     "games/solitaire": {
       "name": "@ai-arcade/solitaire",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@arcade/shared-ui": "*"
+      }
     },
     "games/space-invaders": {
       "name": "@ai-arcade/space-invaders",


### PR DESCRIPTION
## Summary
- Replace custom win overlay with `GameOver` from `@arcade/shared-ui` showing moves and time stats
- Add `GameHeader` component for arcade navigation
- Remove old win overlay HTML and CSS (~35 lines)

Closes #23 (partial - Solitaire)

## Test plan
- [x] All 112 existing tests pass
- [ ] Verify GameHeader displays with back link and title
- [ ] Verify win overlay shows moves and time stats
- [ ] Verify "Play Again" button restarts the game

https://claude.ai/code/session_01PEzDo8iPoQjNJMqKUU4SdH