### PR TITLE
Integrate shared-ui components into Splendor

### DIFF
--- a/games/splendor/index.html
+++ b/games/splendor/index.html
@@ -634,32 +634,6 @@
         margin: 20px 0;
       }
 
-      /* Game over */
-      .game-over-content {
-        padding: 40px;
-      }
-      .game-over-content h1 {
-        font-size: 2.5rem;
-        color: #ffd700;
-        margin-bottom: 10px;
-      }
-      .game-over-content .winner-name {
-        font-size: 1.8rem;
-        color: #a8e6cf;
-        margin-bottom: 20px;
-      }
-      .final-scores {
-        margin: 20px 0;
-      }
-      .final-score-row {
-        display: flex;
-        justify-content: space-between;
-        padding: 8px 16px;
-        background: rgba(255, 255, 255, 0.06);
-        border-radius: 8px;
-        margin: 4px 0;
-      }
-
       /* Chat */
       #chat-toggle {
         position: fixed;
@@ -950,21 +924,6 @@
         <h2>Choose a Noble</h2>
         <p>Multiple nobles wish to visit you!</p>
         <div class="noble-selector" id="noble-selector"></div>
-      </div>
-    </div>
-
-    <div class="overlay" id="game-over-overlay">
-      <div class="overlay-content game-over-content">
-        <h1>Game Over!</h1>
-        <div class="winner-name" id="winner-name"></div>
-        <div class="final-scores" id="final-scores"></div>
-        <button
-          class="primary"
-          onclick="location.reload()"
-          style="margin-top: 20px; font-size: 1.1rem; padding: 12px 30px"
-        >
-          Play Again
-        </button>
       </div>
     </div>
 

--- a/games/splendor/package.json
+++ b/games/splendor/package.json
@@ -8,5 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "@arcade/shared-ui": "*"
   }
 }

--- a/games/splendor/src/ui.js
+++ b/games/splendor/src/ui.js
@@ -4,6 +4,9 @@
  */
 import { GEM_COLORS, GEM_HEX, SplendorGame } from "./engine.js";
 import { SplendorNetwork } from "./network.js";
+import { GameHeader, GameOver } from "@arcade/shared-ui";
+
+const gameOverOverlay = new GameOver();
 
 let game = null;
 let network = null;
@@ -166,6 +169,12 @@ window.copyRoomCode = function () {
 function showGameScreen() {
   document.getElementById("lobby-screen").style.display = "none";
   document.getElementById("game-screen").style.display = "block";
+
+  new GameHeader({
+    title: "Splendor",
+    container: document.getElementById("game-screen"),
+  });
+
   if (isOnline && network) {
     document.getElementById("game-room-code").textContent = "Room: " + (network.roomCode || "");
   }
@@ -645,18 +654,17 @@ function showNobleChoiceOverlay(eligibleNobles) {
 }
 
 function showGameOver() {
-  const overlay = document.getElementById("game-over-overlay");
-  overlay.classList.add("active");
   const winner = game.state.winner || game.getWinner();
-  document.getElementById("winner-name").textContent = `${winner.name} wins!`;
-  const scoresDiv = document.getElementById("final-scores");
-  scoresDiv.innerHTML = "";
-  game.state.players.forEach((p) => {
-    const pts = game._getPlayerPoints(p);
-    const row = document.createElement("div");
-    row.className = "final-score-row";
-    row.innerHTML = `<span>${p.name}</span><span>${pts} points (${p.cards.length} cards)</span>`;
-    scoresDiv.appendChild(row);
+  const stats = game.state.players.map((p) => ({
+    label: p.name,
+    value: `${game._getPlayerPoints(p)} pts`,
+  }));
+
+  gameOverOverlay.show({
+    title: `${winner.name} Wins!`,
+    stats,
+    onRestart: () => location.reload(),
+    restartLabel: "Play Again",
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,10 @@
     },
     "games/splendor": {
       "name": "@ai-arcade/splendor",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@arcade/shared-ui": "*"
+      }
     },
     "games/sudoku": {
       "name": "@ai-arcade/sudoku",


### PR DESCRIPTION
## Summary
- Replace custom game-over overlay with `GameOver` from `@arcade/shared-ui` showing winner and per-player scores
- Add `GameHeader` component for arcade navigation on the game screen
- Remove old game-over overlay HTML and CSS (~40 lines)

Closes #23 (partial - Splendor)

## Test plan
- [x] All 112 existing tests pass
- [ ] Verify GameHeader displays on game screen with back link
- [ ] Verify game-over overlay shows winner name and all player scores
- [ ] Verify "Play Again" button reloads the game

https://claude.ai/code/session_01PEzDo8iPoQjNJMqKUU4SdH