### PR TITLE
Integrate shared-ui components into Space Invaders

### DIFF
--- a/games/space-invaders/package.json
+++ b/games/space-invaders/package.json
@@ -8,5 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "@arcade/shared-ui": "*"
   }
 }

--- a/games/space-invaders/src/ui.js
+++ b/games/space-invaders/src/ui.js
@@ -12,6 +12,7 @@ import {
   createLevelState,
   update,
 } from "./engine.js";
+import { GameHeader, GameOver } from "@arcade/shared-ui";
 
 const canvas = document.getElementById("game");
 const ctx = canvas.getContext("2d");
@@ -27,6 +28,14 @@ canvas.height = H;
 
 const keys = {};
 let state = null;
+
+const gameOverOverlay = new GameOver();
+
+// Add shared GameHeader
+new GameHeader({
+  title: "Space Invaders",
+  container: document.body,
+});
 
 // ---- Input ----
 
@@ -49,6 +58,7 @@ function showOverlay(title, sub, btn) {
 
 window.startGame = function () {
   overlay.style.display = "none";
+  gameOverOverlay.hide();
   state = createGameState(W, H);
 };
 
@@ -214,7 +224,15 @@ function loop() {
     const events = update(state, keys, W, H);
     for (const ev of events) {
       if (ev === "game_over") {
-        showOverlay("GAME OVER", `Final Score: ${state.score}`, "RETRY");
+        gameOverOverlay.show({
+          title: "GAME OVER",
+          stats: [
+            { label: "Score", value: String(state.score) },
+            { label: "Level", value: String(state.level) },
+          ],
+          onRestart: () => window.startGame(),
+          restartLabel: "RETRY",
+        });
       } else if (ev === "level_clear") {
         state.level++;
         const levelState = createLevelState(state.level, W, H);

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,10 @@
     },
     "games/space-invaders": {
       "name": "@ai-arcade/space-invaders",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@arcade/shared-ui": "*"
+      }
     },
     "games/splendor": {
       "name": "@ai-arcade/splendor",


### PR DESCRIPTION
## Summary
- Replace custom game-over overlay with `GameOver` from `@arcade/shared-ui` showing score and level stats
- Add `GameHeader` component for arcade navigation
- Keep existing start screen overlay for initial game instructions

Closes #23 (partial - Space Invaders)

## Test plan
- [x] All 112 existing tests pass
- [ ] Verify GameHeader displays with back link and title
- [ ] Verify game-over overlay shows score and level stats
- [ ] Verify "RETRY" button starts a new game
- [ ] Verify start screen overlay still works for initial play

https://claude.ai/code/session_01PEzDo8iPoQjNJMqKUU4SdH