### PR TITLE
Fix Godot export: download export templates in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup export templates
+        run: |
+          TEMPLATE_DIR="/github/home/.local/share/godot/export_templates/4.6.stable"
+          mkdir -p "$TEMPLATE_DIR"
+          wget -q https://github.com/godotengine/godot/releases/download/4.6-stable/Godot_v4.6-stable_export_templates.tpz -O /tmp/templates.zip
+          unzip -q /tmp/templates.zip -d /tmp/templates
+          mv /tmp/templates/templates/* "$TEMPLATE_DIR/"
+
       - name: Import Godot project
         run: |
           cd games/runner


### PR DESCRIPTION
## Summary
- The `build-godot` deploy job fails because `barichello/godot-ci:4.6` doesn't include export templates
- Add a step to download them from the Godot GitHub release before exporting

## Test plan
- [ ] `build-godot` job completes successfully
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)