### PR TITLE
Polish Zombie Runner: GL renderer, camera, lighting, GLB barrel

### DIFF
--- a/games/runner/project.godot
+++ b/games/runner/project.godot
@@ -16,7 +16,11 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Zombie Lane Runner"
 run/main_scene="res://scenes/main.tscn"
-config/features=PackedStringArray("4.6", "Forward Plus")
+config/features=PackedStringArray("4.6", "GL Compatibility")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
 
 [display]
 

--- a/games/runner/scenes/main.tscn
+++ b/games/runner/scenes/main.tscn
@@ -32,18 +32,18 @@ background_mode = 2
 sky = SubResource("Sky_main")
 ambient_light_source = 2
 ambient_light_color = Color(0.3, 0.3, 0.4, 1)
-ambient_light_energy = 0.5
+ambient_light_energy = 1.5
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_main")
 
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 8, 12)
+transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 8, 8)
 fov = 60.0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 10, 0)
-light_energy = 1.2
+light_energy = 2.5
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_main")

--- a/games/runner/scenes/power_up.tscn
+++ b/games/runner/scenes/power_up.tscn
@@ -1,15 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://power_up_scene"]
+[gd_scene load_steps=4 format=3 uid="uid://power_up_scene"]
 
 [ext_resource type="Script" path="res://scripts/power_up.gd" id="1_power_up"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_barrel"]
-albedo_color = Color(0.8, 0.5, 0.1, 1)
-
-[sub_resource type="CylinderMesh" id="CylinderMesh_barrel"]
-top_radius = 0.5
-bottom_radius = 0.5
-height = 1.0
-material = SubResource("StandardMaterial3D_barrel")
+[ext_resource type="PackedScene" path="res://assets/barrel.glb" id="2_barrel"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_barrel"]
 radius = 0.5
@@ -18,9 +10,8 @@ height = 1.0
 [node name="PowerUp" type="Area3D"]
 script = ExtResource("1_power_up")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-mesh = SubResource("CylinderMesh_barrel")
+[node name="BarrelModel" parent="." instance=ExtResource("2_barrel")]
+transform = Transform3D(2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0)
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)


### PR DESCRIPTION
## Summary
- Switch from Vulkan (Forward Plus) to GL Compatibility renderer to fix `fence_wait` crash on macOS
- Move camera forward (Z 12→8) for better view of the action
- Increase ambient (0.5→1.5) and directional (1.2→2.5) light to compensate for GL renderer
- Replace procedural orange cylinder power-up barrel with GLB barrel asset

## Test plan
- [x] Game launches without Vulkan crash
- [x] Lighting looks appropriate with GL Compatibility renderer
- [x] Power-up barrels render with GLB model and colormap texture
- [x] Hit counter label still displays above barrel
- [ ] Verify on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)