### PR TITLE
feat: add start-issue skill for clean branch setup

### DIFF
--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: start-issue
+description: Use BEFORE starting any new feature, bug fix, issue, or body of work. Pulls latest main and creates a clean feature branch. Must be run before any brainstorming, planning, or implementation.
+allowed-tools: Bash(git *)
+argument-hint: <branch-name>
+---
+
+# Start Working on a New Issue
+
+Set up a clean feature branch from the latest main before doing any work.
+
+1. Ensure working tree is clean (warn if there are uncommitted changes)
+2. Switch to main and pull latest:
+   ```
+   git checkout main
+   git pull origin main
+   ```
+3. Create and switch to a new feature branch named `feat/$ARGUMENTS`
+4. Confirm the branch and status:
+   ```
+   git branch --show-current
+   git status
+   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ Pre-commit hook (husky + lint-staged) runs ESLint and Prettier on staged `.js`, 
 - **CI** (`.github/workflows/ci.yml`): lint, format check, vitest, build, and Godot GUT tests. Node 22.
 - **Deploy** (`.github/workflows/deploy.yml`): Builds all Vite apps + exports Godot runner to web, assembles into GitHub Pages site at `/claude_playground/`.
 
+## Starting New Work
+
+**IMPORTANT:** Before starting any new feature, bug fix, or issue, always run the `/start-issue` skill first to pull latest main and create a clean feature branch. Never start work on a stale branch.
+
 ## Development Workflow (TDD)
 
 Always follow test-driven development. For every feature or bug fix:


### PR DESCRIPTION
## Summary

- Adds `/start-issue` skill that pulls latest main and creates a clean feature branch before starting any new work
- Updates CLAUDE.md to require running this skill before any new feature or bug fix
- Skill can be invoked automatically by Claude or manually via `/start-issue <branch-name>`

## Test plan

- [ ] `/start-issue some-feature` creates `feat/some-feature` from latest main
- [ ] Warns if working tree has uncommitted changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)