### PR TITLE
test(ai-metrics): scaffold dashboard package with failing engine tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,9 +104,13 @@ jobs:
       - name: Assemble site
         run: |
           mkdir _site
-          # Copy Vite-built games and apps
+          # Copy Vite-built games and apps. The `landing` package is special:
+          # its output becomes the Pages root, not a subdirectory.
           for pkg in games/*/ apps/*/; do
             name=$(basename "$pkg")
+            if [ "$name" = "landing" ]; then
+              continue
+            fi
             if [ -d "$pkg/dist" ]; then
               cp -r "$pkg/dist" "_site/$name"
             fi
@@ -114,6 +118,10 @@ jobs:
           # Copy Godot-exported game
           if [ -d "godot-export" ]; then
             cp -r godot-export _site/runner
+          fi
+          # Copy root landing page last so it takes the top-level slot
+          if [ -d "apps/landing/dist" ]; then
+            cp -r apps/landing/dist/. _site/
           fi
 
       - name: Upload Pages artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,15 @@ Pre-commit hook (husky + lint-staged) runs ESLint and Prettier on staged `.js`, 
 - **`apps/*`** — Non-game apps (same structure as games).
 - **`packages/shared-ui`** — Shared UI components (game-header, game-over, modal, theme CSS). Games depend on it via `@arcade/shared-ui`.
 - **`games/runner`** — Godot 4.6 project (GDScript, not JS). Excluded from ESLint. Uses GUT for testing; CI runs tests in a `barichello/godot-ci:4.6` container.
-- **`games/arcade-hub`** — Landing page that links to all games.
+- **`apps/landing`** — Root GitHub Pages landing page. Uses a custom `vite.config.js` (not `createGameConfig()`) so its `base` is `/claude_playground/` rather than `/claude_playground/landing/`. The deploy workflow copies its dist contents into `_site/` root instead of a subdirectory.
+- **`games/arcade-hub`** — Games-only gateway linked from the root landing page.
+- **`apps/ai-metrics`** — Dashboard for tracking AI model usage; pure engine in `src/metrics.js` with full Vitest coverage. See `apps/ai-metrics/README.md`.
 
 ## CI/CD
 
 - **CI Web** (`.github/workflows/ci-web.yml`): lint, format check, vitest, build. Triggers on JS/Vite file changes. Node 22.
 - **CI Godot** (`.github/workflows/ci-godot.yml`): GUT tests in `barichello/godot-ci:4.6` container. Triggers on `games/runner/` changes.
-- **Deploy** (`.github/workflows/deploy.yml`): Builds all Vite apps + exports Godot runner to web, assembles into GitHub Pages site at `/claude_playground/`.
+- **Deploy** (`.github/workflows/deploy.yml`): Builds all Vite apps + exports Godot runner to web, assembles into GitHub Pages site at `/claude_playground/`. `apps/landing` is special-cased in the assembly step: its dist contents are copied to `_site/` root so it owns the top-level `index.html`.
 
 ## Starting New Work
 

--- a/apps/ai-metrics/README.md
+++ b/apps/ai-metrics/README.md
@@ -1,0 +1,82 @@
+# ai-metrics
+
+> A browser-based dashboard for tracking your progress using Claude and other AI models. Vanilla JS + Vite, fully client-side, data persisted to `localStorage`.
+
+Log the sessions you have with AI models (Claude, GPT, Gemini, etc.), then review aggregates — time spent, token and cost totals, streaks, week-over-week deltas, and breakdowns by model and category. Nothing is sent to a server; everything lives in your browser.
+
+## Running locally
+
+```bash
+npm run dev --workspace apps/ai-metrics
+```
+
+Vite starts on [http://localhost:3010/](http://localhost:3010/) and auto-opens your browser. On first load the dashboard is empty — click **"Load sample"** in the header to populate it with ~13 fake sessions spread across the last two weeks so every chart has something to render. Or just start logging real sessions with the "Log a session" form.
+
+## Features
+
+**Summary cards** (top of page)
+
+- **Total sessions** — lifetime count, with this-week count as a sub-stat
+- **Time logged** — lifetime minutes formatted as hours/minutes
+- **Day streak** — consecutive days with at least one session, allowing the streak to end at yesterday if today is empty
+- **Week over week** — percent change in session count between the trailing 7 days and the 7 days before that
+- **Avg rating** — mean of user-provided 1–5 ratings (only rated sessions are counted)
+- **Total cost** — sum of per-session USD costs, with total token count as a sub-stat
+
+**Charts**
+
+- **Activity** — 30-day rolling SVG bar chart of sessions per day
+- **By model** — horizontal bars of minutes spent per model, top 8
+- **By category** — horizontal bars of minutes spent per category, top 8
+- **Top tags** — tag cloud showing the 12 most-used tags
+
+**Sessions table** — every logged session with filters for model, category, and a free-text search across notes and tags. Each row has a Delete button.
+
+**Header actions** — Export (download all sessions as JSON), Import (replace current data with a JSON file), Load sample (append demo data), Reset (clear everything).
+
+## Session data model
+
+Every entry is normalized through `createSession()` in `src/metrics.js:29` into this shape:
+
+| Field              | Type          | Notes                                             |
+| ------------------ | ------------- | ------------------------------------------------- |
+| `id`               | string        | Auto-generated if missing                         |
+| `timestamp`        | number (ms)   | Defaults to `Date.now()`                          |
+| `model`            | string        | Free text, e.g. `claude-opus-4-6`, `gpt-4o`       |
+| `category`         | string        | `coding`, `writing`, `research`, `analysis`, etc. |
+| `durationMinutes`  | number ≥ 0    | How long the session lasted                       |
+| `promptTokens`     | number ≥ 0    | Optional                                          |
+| `completionTokens` | number ≥ 0    | Optional                                          |
+| `cost`             | number ≥ 0    | USD                                               |
+| `rating`           | 1–5 or `null` | `null` means "not rated"                          |
+| `notes`            | string        | Free-form                                         |
+| `tags`             | string[]      | Lowercased, comma-separated in the form           |
+
+Invalid numeric fields are coerced to `0`. Missing strings fall back to sensible defaults (`"unknown"` for model, `"other"` for category).
+
+## Persistence
+
+Sessions are serialized to `localStorage` under the key `ai_metrics_dashboard_v1`. To inspect or wipe the store manually:
+
+```js
+// DevTools console
+JSON.parse(localStorage.getItem("ai_metrics_dashboard_v1"));
+localStorage.removeItem("ai_metrics_dashboard_v1");
+```
+
+Use **Export** from the header to download a JSON backup, and **Import** to restore it on another machine or browser.
+
+## Architecture
+
+- **`src/metrics.js`** — pure engine. No DOM, no storage, no side effects. All aggregation functions (`computeSummary`, `groupByModel`/`Category`/`Day`, `computeStreak`, `computeWeekOverWeek`, `topTags`) take a session array and return derived data. Fully unit-tested.
+- **`src/main.js`** — UI controller. Handles localStorage, form events, filters, rendering, and sample/import/export.
+- **`index.html` + `style.css`** — static shell and theme.
+
+Tests live in `src/__tests__/metrics.test.js` and run via the root `npm run test`. The engine is the trusted source of truth for every number shown on the dashboard, so if a metric looks wrong, start with the corresponding test.
+
+## Tips
+
+- **Tag aggressively.** Tags are the only freeform axis for searching sessions later. `frontend`, `bug`, `refactor`, `learning`, and project names all work well.
+- **Rate for signal, not perfectionism.** The avg rating card is most useful when you rate consistently. Skip ratings on sessions where quality doesn't matter (quick edits, tool calls) — `null` ratings are excluded from the average.
+- **Treat duration as wall-clock, not active.** It's easier to log "I spent 45 minutes on this" than to stopwatch every prompt.
+- **Export weekly.** LocalStorage is durable but not backed up. A weekly JSON export to cloud storage or a git repo gives you safety and a long-term archive.

--- a/apps/ai-metrics/index.html
+++ b/apps/ai-metrics/index.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Metrics Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <header class="page-header">
+        <div>
+          <h1>AI Metrics</h1>
+          <p class="subtitle">Track your progress with Claude and other AI models</p>
+        </div>
+        <div class="header-actions">
+          <button class="btn btn-secondary" id="btn-export">Export</button>
+          <button class="btn btn-secondary" id="btn-import">Import</button>
+          <input type="file" id="import-input" accept=".json" hidden />
+          <button class="btn btn-secondary" id="btn-sample">Load sample</button>
+          <button class="btn btn-danger" id="btn-reset">Reset</button>
+        </div>
+      </header>
+
+      <section class="summary-cards" id="summary-cards"></section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>Log a session</h2>
+          <p class="card-sub">Record a single AI interaction</p>
+        </div>
+        <form id="session-form" class="session-form">
+          <div class="form-row">
+            <label class="field">
+              <span>Date &amp; time</span>
+              <input type="datetime-local" id="f-timestamp" required />
+            </label>
+            <label class="field">
+              <span>Model</span>
+              <input
+                type="text"
+                id="f-model"
+                list="model-suggestions"
+                placeholder="claude-opus-4-6"
+                required
+              />
+              <datalist id="model-suggestions">
+                <option value="claude-opus-4-6"></option>
+                <option value="claude-sonnet-4-6"></option>
+                <option value="claude-haiku-4-5"></option>
+                <option value="gpt-4o"></option>
+                <option value="gpt-4.1"></option>
+                <option value="gemini-2.5-pro"></option>
+                <option value="llama-3.1"></option>
+              </datalist>
+            </label>
+            <label class="field">
+              <span>Category</span>
+              <select id="f-category">
+                <option value="coding">Coding</option>
+                <option value="writing">Writing</option>
+                <option value="research">Research</option>
+                <option value="analysis">Analysis</option>
+                <option value="brainstorm">Brainstorm</option>
+                <option value="learning">Learning</option>
+                <option value="other">Other</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-row">
+            <label class="field">
+              <span>Duration (min)</span>
+              <input type="number" id="f-duration" min="0" step="1" value="15" />
+            </label>
+            <label class="field">
+              <span>Prompt tokens</span>
+              <input type="number" id="f-prompt-tokens" min="0" step="1" placeholder="0" />
+            </label>
+            <label class="field">
+              <span>Completion tokens</span>
+              <input type="number" id="f-completion-tokens" min="0" step="1" placeholder="0" />
+            </label>
+            <label class="field">
+              <span>Cost (USD)</span>
+              <input type="number" id="f-cost" min="0" step="0.01" placeholder="0.00" />
+            </label>
+            <label class="field">
+              <span>Rating</span>
+              <select id="f-rating">
+                <option value="">—</option>
+                <option value="1">1 — poor</option>
+                <option value="2">2</option>
+                <option value="3">3 — ok</option>
+                <option value="4">4</option>
+                <option value="5">5 — great</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-row">
+            <label class="field field-grow">
+              <span>Tags (comma separated)</span>
+              <input type="text" id="f-tags" placeholder="frontend, refactor, tdd" />
+            </label>
+            <label class="field field-grow">
+              <span>Notes</span>
+              <input type="text" id="f-notes" placeholder="What did you work on?" />
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Add session</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="grid-2">
+        <div class="card">
+          <div class="card-header">
+            <h2>Activity</h2>
+            <p class="card-sub">Sessions per day (last 30)</p>
+          </div>
+          <div id="chart-activity" class="chart-container"></div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <h2>By model</h2>
+            <p class="card-sub">Time spent and usage</p>
+          </div>
+          <div id="chart-models" class="bars-container"></div>
+        </div>
+      </section>
+
+      <section class="grid-2">
+        <div class="card">
+          <div class="card-header">
+            <h2>By category</h2>
+            <p class="card-sub">Where your AI time goes</p>
+          </div>
+          <div id="chart-categories" class="bars-container"></div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <h2>Top tags</h2>
+            <p class="card-sub">Most common topics</p>
+          </div>
+          <div id="top-tags" class="tag-cloud"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>Sessions</h2>
+          <p class="card-sub" id="sessions-meta"></p>
+        </div>
+        <div class="filter-row">
+          <label class="field">
+            <span>Filter model</span>
+            <select id="filter-model">
+              <option value="">All models</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Filter category</span>
+            <select id="filter-category">
+              <option value="">All categories</option>
+            </select>
+          </label>
+          <label class="field field-grow">
+            <span>Search notes / tags</span>
+            <input type="text" id="filter-search" placeholder="e.g. refactor" />
+          </label>
+        </div>
+        <div class="table-wrap">
+          <table class="session-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Model</th>
+                <th>Category</th>
+                <th class="num">Min</th>
+                <th class="num">Tokens</th>
+                <th class="num">Cost</th>
+                <th class="num">Rating</th>
+                <th>Notes</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="session-tbody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer class="page-footer">
+        Data is stored locally in your browser. Export the JSON if you want to keep it safe.
+      </footer>
+    </div>
+
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/apps/ai-metrics/package.json
+++ b/apps/ai-metrics/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ai-arcade/ai-metrics",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Dashboard to review metrics on your progress using Claude and other AI models",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/apps/ai-metrics/src/__tests__/metrics.test.js
+++ b/apps/ai-metrics/src/__tests__/metrics.test.js
@@ -1,0 +1,338 @@
+import { describe, it, expect } from "vitest";
+import {
+  createSession,
+  computeSummary,
+  groupByModel,
+  groupByCategory,
+  groupByDay,
+  computeStreak,
+  computeWeekOverWeek,
+  topTags,
+  toIsoDay,
+} from "../metrics.js";
+
+// Deterministic reference point used across time-sensitive tests.
+// Monday, 2026-04-13 12:00 UTC
+const REF = Date.UTC(2026, 3, 13, 12, 0, 0);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function at(daysAgo, hour = 10) {
+  return REF - daysAgo * DAY_MS + (hour - 12) * 3600 * 1000;
+}
+
+describe("createSession", () => {
+  it("fills in defaults for missing fields", () => {
+    const s = createSession({});
+    expect(typeof s.id).toBe("string");
+    expect(s.id.length).toBeGreaterThan(0);
+    expect(typeof s.timestamp).toBe("number");
+    expect(s.model).toBe("unknown");
+    expect(s.category).toBe("other");
+    expect(s.durationMinutes).toBe(0);
+    expect(s.promptTokens).toBe(0);
+    expect(s.completionTokens).toBe(0);
+    expect(s.cost).toBe(0);
+    expect(s.rating).toBeNull();
+    expect(s.notes).toBe("");
+    expect(s.tags).toEqual([]);
+  });
+
+  it("preserves provided values", () => {
+    const s = createSession({
+      id: "abc",
+      timestamp: 42,
+      model: "claude-opus-4-6",
+      category: "coding",
+      durationMinutes: 30,
+      promptTokens: 100,
+      completionTokens: 200,
+      cost: 0.5,
+      rating: 4,
+      notes: "hello",
+      tags: ["x", "y"],
+    });
+    expect(s.id).toBe("abc");
+    expect(s.timestamp).toBe(42);
+    expect(s.model).toBe("claude-opus-4-6");
+    expect(s.category).toBe("coding");
+    expect(s.durationMinutes).toBe(30);
+    expect(s.promptTokens).toBe(100);
+    expect(s.completionTokens).toBe(200);
+    expect(s.cost).toBe(0.5);
+    expect(s.rating).toBe(4);
+    expect(s.notes).toBe("hello");
+    expect(s.tags).toEqual(["x", "y"]);
+  });
+
+  it("generates unique ids across calls", () => {
+    const a = createSession({});
+    const b = createSession({});
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("copies tags array so caller mutation does not leak", () => {
+    const tags = ["a"];
+    const s = createSession({ tags });
+    tags.push("b");
+    expect(s.tags).toEqual(["a"]);
+  });
+
+  it("coerces invalid numeric fields to safe defaults", () => {
+    const s = createSession({
+      durationMinutes: "oops",
+      promptTokens: NaN,
+      cost: null,
+      rating: "nope",
+    });
+    expect(s.durationMinutes).toBe(0);
+    expect(s.promptTokens).toBe(0);
+    expect(s.cost).toBe(0);
+    expect(s.rating).toBeNull();
+  });
+});
+
+describe("computeSummary", () => {
+  it("returns zero totals for an empty list", () => {
+    const s = computeSummary([]);
+    expect(s).toEqual({
+      totalSessions: 0,
+      totalMinutes: 0,
+      totalPromptTokens: 0,
+      totalCompletionTokens: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      averageRating: 0,
+      ratedCount: 0,
+    });
+  });
+
+  it("sums totals across sessions", () => {
+    const sessions = [
+      createSession({ durationMinutes: 10, promptTokens: 100, completionTokens: 50, cost: 0.2, rating: 4 }),
+      createSession({ durationMinutes: 20, promptTokens: 200, completionTokens: 100, cost: 0.5, rating: 5 }),
+      createSession({ durationMinutes: 5, promptTokens: 50, completionTokens: 25, cost: 0.1 }),
+    ];
+    const s = computeSummary(sessions);
+    expect(s.totalSessions).toBe(3);
+    expect(s.totalMinutes).toBe(35);
+    expect(s.totalPromptTokens).toBe(350);
+    expect(s.totalCompletionTokens).toBe(175);
+    expect(s.totalTokens).toBe(525);
+    expect(s.totalCost).toBeCloseTo(0.8, 5);
+    expect(s.ratedCount).toBe(2);
+    expect(s.averageRating).toBeCloseTo(4.5, 5);
+  });
+
+  it("returns averageRating 0 when no sessions are rated", () => {
+    const sessions = [createSession({ durationMinutes: 5 }), createSession({ durationMinutes: 10 })];
+    const s = computeSummary(sessions);
+    expect(s.averageRating).toBe(0);
+    expect(s.ratedCount).toBe(0);
+  });
+});
+
+describe("groupByModel", () => {
+  it("aggregates sessions by model", () => {
+    const sessions = [
+      createSession({ model: "claude-opus-4-6", durationMinutes: 30, promptTokens: 100, completionTokens: 50, cost: 0.3, rating: 5 }),
+      createSession({ model: "claude-opus-4-6", durationMinutes: 10, promptTokens: 20, completionTokens: 10, cost: 0.1, rating: 3 }),
+      createSession({ model: "gpt-4o", durationMinutes: 15, promptTokens: 200, completionTokens: 100, cost: 0.4, rating: 4 }),
+    ];
+    const groups = groupByModel(sessions);
+    expect(groups.length).toBe(2);
+    const opus = groups.find((g) => g.key === "claude-opus-4-6");
+    const gpt = groups.find((g) => g.key === "gpt-4o");
+    expect(opus.count).toBe(2);
+    expect(opus.minutes).toBe(40);
+    expect(opus.tokens).toBe(180);
+    expect(opus.cost).toBeCloseTo(0.4, 5);
+    expect(opus.averageRating).toBeCloseTo(4, 5);
+    expect(gpt.count).toBe(1);
+    expect(gpt.tokens).toBe(300);
+  });
+
+  it("sorts groups by count descending", () => {
+    const sessions = [
+      createSession({ model: "a" }),
+      createSession({ model: "b" }),
+      createSession({ model: "b" }),
+      createSession({ model: "c" }),
+      createSession({ model: "c" }),
+      createSession({ model: "c" }),
+    ];
+    const groups = groupByModel(sessions);
+    expect(groups.map((g) => g.key)).toEqual(["c", "b", "a"]);
+  });
+
+  it("treats missing model as 'unknown'", () => {
+    const sessions = [{ model: "", durationMinutes: 5, timestamp: 0 }];
+    const groups = groupByModel(sessions);
+    expect(groups[0].key).toBe("unknown");
+  });
+});
+
+describe("groupByCategory", () => {
+  it("aggregates sessions by category", () => {
+    const sessions = [
+      createSession({ category: "coding", durationMinutes: 30 }),
+      createSession({ category: "coding", durationMinutes: 15 }),
+      createSession({ category: "writing", durationMinutes: 20 }),
+    ];
+    const groups = groupByCategory(sessions);
+    const coding = groups.find((g) => g.key === "coding");
+    const writing = groups.find((g) => g.key === "writing");
+    expect(coding.count).toBe(2);
+    expect(coding.minutes).toBe(45);
+    expect(writing.count).toBe(1);
+    expect(writing.minutes).toBe(20);
+  });
+});
+
+describe("toIsoDay", () => {
+  it("formats a timestamp as YYYY-MM-DD in UTC", () => {
+    expect(toIsoDay(Date.UTC(2026, 0, 1, 0, 0, 0))).toBe("2026-01-01");
+    expect(toIsoDay(Date.UTC(2026, 3, 13, 23, 59, 59))).toBe("2026-04-13");
+  });
+});
+
+describe("groupByDay", () => {
+  it("groups sessions by UTC day, sorted ascending", () => {
+    const sessions = [
+      createSession({ timestamp: at(2), durationMinutes: 10 }),
+      createSession({ timestamp: at(0), durationMinutes: 20 }),
+      createSession({ timestamp: at(0), durationMinutes: 5 }),
+      createSession({ timestamp: at(5), durationMinutes: 15 }),
+    ];
+    const days = groupByDay(sessions);
+    expect(days.length).toBe(3);
+    expect(days[0].day < days[1].day).toBe(true);
+    expect(days[days.length - 1].day).toBe(toIsoDay(at(0)));
+    const today = days.find((d) => d.day === toIsoDay(at(0)));
+    expect(today.count).toBe(2);
+    expect(today.minutes).toBe(25);
+  });
+
+  it("returns empty array for no sessions", () => {
+    expect(groupByDay([])).toEqual([]);
+  });
+});
+
+describe("computeStreak", () => {
+  it("returns 0 for no sessions", () => {
+    expect(computeStreak([], REF)).toBe(0);
+  });
+
+  it("returns 1 when only today has a session", () => {
+    const sessions = [createSession({ timestamp: at(0) })];
+    expect(computeStreak(sessions, REF)).toBe(1);
+  });
+
+  it("counts consecutive days leading up to today", () => {
+    const sessions = [
+      createSession({ timestamp: at(0) }),
+      createSession({ timestamp: at(1) }),
+      createSession({ timestamp: at(2) }),
+      createSession({ timestamp: at(4) }), // gap at day 3 breaks streak
+    ];
+    expect(computeStreak(sessions, REF)).toBe(3);
+  });
+
+  it("allows streak to end at yesterday when today is empty", () => {
+    const sessions = [
+      createSession({ timestamp: at(1) }),
+      createSession({ timestamp: at(2) }),
+    ];
+    expect(computeStreak(sessions, REF)).toBe(2);
+  });
+
+  it("returns 0 when the most recent session is older than yesterday", () => {
+    const sessions = [
+      createSession({ timestamp: at(3) }),
+      createSession({ timestamp: at(4) }),
+    ];
+    expect(computeStreak(sessions, REF)).toBe(0);
+  });
+
+  it("treats multiple sessions on the same day as one day", () => {
+    const sessions = [
+      createSession({ timestamp: at(0, 9) }),
+      createSession({ timestamp: at(0, 15) }),
+      createSession({ timestamp: at(1, 10) }),
+    ];
+    expect(computeStreak(sessions, REF)).toBe(2);
+  });
+});
+
+describe("computeWeekOverWeek", () => {
+  it("splits sessions into current and previous 7-day windows", () => {
+    const sessions = [
+      createSession({ timestamp: at(0), durationMinutes: 10 }), // current
+      createSession({ timestamp: at(3), durationMinutes: 20 }), // current
+      createSession({ timestamp: at(6), durationMinutes: 5 }), // current (within 7 days)
+      createSession({ timestamp: at(8), durationMinutes: 15 }), // previous
+      createSession({ timestamp: at(13), durationMinutes: 10 }), // previous (boundary inside)
+      createSession({ timestamp: at(20), durationMinutes: 100 }), // outside both
+    ];
+    const wow = computeWeekOverWeek(sessions, REF);
+    expect(wow.current.count).toBe(3);
+    expect(wow.current.minutes).toBe(35);
+    expect(wow.previous.count).toBe(2);
+    expect(wow.previous.minutes).toBe(25);
+  });
+
+  it("returns 0 percent change when both periods are empty", () => {
+    const wow = computeWeekOverWeek([], REF);
+    expect(wow.percentChangeCount).toBe(0);
+    expect(wow.percentChangeMinutes).toBe(0);
+  });
+
+  it("returns 100 percent change when previous is zero but current is not", () => {
+    const sessions = [createSession({ timestamp: at(0), durationMinutes: 10 })];
+    const wow = computeWeekOverWeek(sessions, REF);
+    expect(wow.percentChangeCount).toBe(100);
+    expect(wow.percentChangeMinutes).toBe(100);
+  });
+
+  it("computes signed percent change", () => {
+    const sessions = [
+      createSession({ timestamp: at(0), durationMinutes: 5 }),
+      createSession({ timestamp: at(8), durationMinutes: 10 }),
+      createSession({ timestamp: at(10), durationMinutes: 10 }),
+    ];
+    const wow = computeWeekOverWeek(sessions, REF);
+    // current = 1 session, previous = 2 sessions → -50%
+    expect(wow.percentChangeCount).toBeCloseTo(-50, 5);
+    // current minutes = 5, previous minutes = 20 → -75%
+    expect(wow.percentChangeMinutes).toBeCloseTo(-75, 5);
+  });
+});
+
+describe("topTags", () => {
+  it("returns most-used tags in descending order", () => {
+    const sessions = [
+      createSession({ tags: ["js", "bug", "frontend"] }),
+      createSession({ tags: ["js", "frontend"] }),
+      createSession({ tags: ["js"] }),
+      createSession({ tags: ["docs"] }),
+    ];
+    const top = topTags(sessions, 3);
+    expect(top).toEqual([
+      { tag: "js", count: 3 },
+      { tag: "frontend", count: 2 },
+      // the 3rd slot is either "bug" or "docs" (both count 1); allow either
+      expect.objectContaining({ count: 1 }),
+    ]);
+  });
+
+  it("respects the limit parameter", () => {
+    const sessions = [
+      createSession({ tags: ["a", "b", "c", "d"] }),
+      createSession({ tags: ["a", "b", "c"] }),
+    ];
+    expect(topTags(sessions, 2).length).toBe(2);
+  });
+
+  it("returns an empty array when there are no tags", () => {
+    expect(topTags([createSession({})])).toEqual([]);
+  });
+});

--- a/apps/ai-metrics/src/__tests__/metrics.test.js
+++ b/apps/ai-metrics/src/__tests__/metrics.test.js
@@ -108,8 +108,20 @@ describe("computeSummary", () => {
 
   it("sums totals across sessions", () => {
     const sessions = [
-      createSession({ durationMinutes: 10, promptTokens: 100, completionTokens: 50, cost: 0.2, rating: 4 }),
-      createSession({ durationMinutes: 20, promptTokens: 200, completionTokens: 100, cost: 0.5, rating: 5 }),
+      createSession({
+        durationMinutes: 10,
+        promptTokens: 100,
+        completionTokens: 50,
+        cost: 0.2,
+        rating: 4,
+      }),
+      createSession({
+        durationMinutes: 20,
+        promptTokens: 200,
+        completionTokens: 100,
+        cost: 0.5,
+        rating: 5,
+      }),
       createSession({ durationMinutes: 5, promptTokens: 50, completionTokens: 25, cost: 0.1 }),
     ];
     const s = computeSummary(sessions);
@@ -124,7 +136,10 @@ describe("computeSummary", () => {
   });
 
   it("returns averageRating 0 when no sessions are rated", () => {
-    const sessions = [createSession({ durationMinutes: 5 }), createSession({ durationMinutes: 10 })];
+    const sessions = [
+      createSession({ durationMinutes: 5 }),
+      createSession({ durationMinutes: 10 }),
+    ];
     const s = computeSummary(sessions);
     expect(s.averageRating).toBe(0);
     expect(s.ratedCount).toBe(0);
@@ -134,9 +149,30 @@ describe("computeSummary", () => {
 describe("groupByModel", () => {
   it("aggregates sessions by model", () => {
     const sessions = [
-      createSession({ model: "claude-opus-4-6", durationMinutes: 30, promptTokens: 100, completionTokens: 50, cost: 0.3, rating: 5 }),
-      createSession({ model: "claude-opus-4-6", durationMinutes: 10, promptTokens: 20, completionTokens: 10, cost: 0.1, rating: 3 }),
-      createSession({ model: "gpt-4o", durationMinutes: 15, promptTokens: 200, completionTokens: 100, cost: 0.4, rating: 4 }),
+      createSession({
+        model: "claude-opus-4-6",
+        durationMinutes: 30,
+        promptTokens: 100,
+        completionTokens: 50,
+        cost: 0.3,
+        rating: 5,
+      }),
+      createSession({
+        model: "claude-opus-4-6",
+        durationMinutes: 10,
+        promptTokens: 20,
+        completionTokens: 10,
+        cost: 0.1,
+        rating: 3,
+      }),
+      createSession({
+        model: "gpt-4o",
+        durationMinutes: 15,
+        promptTokens: 200,
+        completionTokens: 100,
+        cost: 0.4,
+        rating: 4,
+      }),
     ];
     const groups = groupByModel(sessions);
     expect(groups.length).toBe(2);
@@ -238,18 +274,12 @@ describe("computeStreak", () => {
   });
 
   it("allows streak to end at yesterday when today is empty", () => {
-    const sessions = [
-      createSession({ timestamp: at(1) }),
-      createSession({ timestamp: at(2) }),
-    ];
+    const sessions = [createSession({ timestamp: at(1) }), createSession({ timestamp: at(2) })];
     expect(computeStreak(sessions, REF)).toBe(2);
   });
 
   it("returns 0 when the most recent session is older than yesterday", () => {
-    const sessions = [
-      createSession({ timestamp: at(3) }),
-      createSession({ timestamp: at(4) }),
-    ];
+    const sessions = [createSession({ timestamp: at(3) }), createSession({ timestamp: at(4) })];
     expect(computeStreak(sessions, REF)).toBe(0);
   });
 

--- a/apps/ai-metrics/src/main.js
+++ b/apps/ai-metrics/src/main.js
@@ -1,0 +1,688 @@
+/**
+ * AI Metrics Dashboard — UI controller.
+ *
+ * Responsibilities:
+ *   - Persist sessions to localStorage
+ *   - Wire form submit, filters, import/export, reset, sample loader
+ *   - Render summary cards, charts, and the session table whenever state changes
+ *
+ * All statistics come from the pure metrics engine in ./metrics.js.
+ */
+import {
+  createSession,
+  computeSummary,
+  groupByModel,
+  groupByCategory,
+  groupByDay,
+  computeStreak,
+  computeWeekOverWeek,
+  topTags,
+  toIsoDay,
+} from "./metrics.js";
+
+const STORAGE_KEY = "ai_metrics_dashboard_v1";
+const CHART_COLORS = ["#58a6ff", "#a371f7", "#3fb950", "#f0883e", "#e685b5", "#79c0ff"];
+
+// ---------- state ----------
+
+let sessions = loadSessions();
+const filters = { model: "", category: "", search: "" };
+
+function loadSessions() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((s) => createSession(s));
+  } catch {
+    return [];
+  }
+}
+
+function saveSessions() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+}
+
+function addSession(partial) {
+  sessions.push(createSession(partial));
+  sessions.sort((a, b) => b.timestamp - a.timestamp);
+  saveSessions();
+  render();
+}
+
+function deleteSession(id) {
+  sessions = sessions.filter((s) => s.id !== id);
+  saveSessions();
+  render();
+}
+
+// ---------- helpers ----------
+
+function formatDateTimeLocal(ts) {
+  // For <input type="datetime-local"> — local timezone, no seconds.
+  const d = new Date(ts);
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function parseDateTimeLocal(value) {
+  // Returns ms epoch or NaN.
+  if (!value) return NaN;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+function formatHours(totalMinutes) {
+  if (totalMinutes < 60) return `${Math.round(totalMinutes)}m`;
+  const h = Math.floor(totalMinutes / 60);
+  const m = Math.round(totalMinutes % 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+function formatNumber(n) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+function formatCost(n) {
+  return `$${n.toFixed(2)}`;
+}
+
+function formatRating(r) {
+  return r > 0 ? `${r.toFixed(1)}★` : "—";
+}
+
+function formatDeltaPct(pct) {
+  if (!Number.isFinite(pct)) return "";
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${Math.round(pct)}%`;
+}
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text === null || text === undefined ? "" : String(text);
+  return div.innerHTML;
+}
+
+function parseTags(input) {
+  return input
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function applyFilters(list) {
+  const needle = filters.search.trim().toLowerCase();
+  return list.filter((s) => {
+    if (filters.model && s.model !== filters.model) return false;
+    if (filters.category && s.category !== filters.category) return false;
+    if (needle) {
+      const hay = `${s.notes} ${s.tags.join(" ")}`.toLowerCase();
+      if (!hay.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+// ---------- rendering ----------
+
+function renderSummaryCards(now) {
+  const summary = computeSummary(sessions);
+  const streak = computeStreak(sessions, now);
+  const wow = computeWeekOverWeek(sessions, now);
+  const wowArrow = wow.percentChangeCount >= 0 ? "up" : "down";
+
+  const cards = [
+    {
+      label: "Total sessions",
+      value: String(summary.totalSessions),
+      delta: `${wow.current.count} this week`,
+      deltaClass: "",
+    },
+    {
+      label: "Time logged",
+      value: formatHours(summary.totalMinutes),
+      delta: `${formatHours(wow.current.minutes)} this week`,
+      deltaClass: "",
+    },
+    {
+      label: "Day streak",
+      value: `${streak}🔥`,
+      delta: streak > 0 ? "keep it up" : "log a session today",
+      deltaClass: "",
+    },
+    {
+      label: "Week over week",
+      value: formatDeltaPct(wow.percentChangeCount),
+      delta: `${wow.previous.count} prior → ${wow.current.count} now`,
+      deltaClass: wowArrow,
+    },
+    {
+      label: "Avg rating",
+      value: formatRating(summary.averageRating),
+      delta: `${summary.ratedCount}/${summary.totalSessions} rated`,
+      deltaClass: "",
+    },
+    {
+      label: "Total cost",
+      value: formatCost(summary.totalCost),
+      delta: `${formatNumber(summary.totalTokens)} tokens`,
+      deltaClass: "",
+    },
+  ];
+
+  const container = document.getElementById("summary-cards");
+  container.innerHTML = cards
+    .map(
+      (c) => `
+      <div class="summary-card">
+        <span class="label">${escapeHtml(c.label)}</span>
+        <span class="value">${escapeHtml(c.value)}</span>
+        <span class="delta ${c.deltaClass}">${escapeHtml(c.delta)}</span>
+      </div>
+    `,
+    )
+    .join("");
+}
+
+function renderActivityChart(now) {
+  const container = document.getElementById("chart-activity");
+  const grouped = groupByDay(sessions);
+  const byDay = new Map(grouped.map((d) => [d.day, d]));
+
+  // Always show a rolling 30-day window ending today.
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const days = [];
+  for (let i = 29; i >= 0; i--) {
+    const ts = now - i * DAY_MS;
+    const key = toIsoDay(ts);
+    const bucket = byDay.get(key) || { day: key, count: 0, minutes: 0 };
+    days.push(bucket);
+  }
+
+  const maxCount = Math.max(1, ...days.map((d) => d.count));
+  const width = 600;
+  const height = 160;
+  const padding = { top: 12, right: 8, bottom: 24, left: 24 };
+  const chartW = width - padding.left - padding.right;
+  const chartH = height - padding.top - padding.bottom;
+  const barW = chartW / days.length;
+
+  const bars = days
+    .map((d, i) => {
+      const h = (d.count / maxCount) * chartH;
+      const x = padding.left + i * barW + 1;
+      const y = padding.top + (chartH - h);
+      const label = `${d.day}: ${d.count} session${d.count === 1 ? "" : "s"}`;
+      return `<rect class="bar-day" x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${(barW - 2).toFixed(2)}" height="${h.toFixed(2)}" rx="1"><title>${escapeHtml(label)}</title></rect>`;
+    })
+    .join("");
+
+  // X-axis labels at ~5 positions
+  const xLabels = [
+    0,
+    Math.floor(days.length / 4),
+    Math.floor(days.length / 2),
+    Math.floor((days.length * 3) / 4),
+    days.length - 1,
+  ]
+    .map((i) => {
+      const d = days[i];
+      const parts = d.day.split("-");
+      const label = `${parts[1]}/${parts[2]}`;
+      const x = padding.left + i * barW + barW / 2;
+      return `<text class="axis-label" x="${x.toFixed(2)}" y="${height - 6}" text-anchor="middle">${label}</text>`;
+    })
+    .join("");
+
+  // Y-axis gridlines at 0, mid, max
+  const yMid = padding.top + chartH / 2;
+  const yBottom = padding.top + chartH;
+  const gridlines = `
+    <line class="axis-line" x1="${padding.left}" y1="${yBottom}" x2="${width - padding.right}" y2="${yBottom}" />
+    <text class="axis-label" x="${padding.left - 4}" y="${padding.top + 4}" text-anchor="end">${maxCount}</text>
+    <text class="axis-label" x="${padding.left - 4}" y="${yMid + 3}" text-anchor="end">${Math.round(maxCount / 2)}</text>
+    <text class="axis-label" x="${padding.left - 4}" y="${yBottom + 3}" text-anchor="end">0</text>
+  `;
+
+  container.innerHTML = `
+    <svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="Daily session activity">
+      ${gridlines}
+      ${bars}
+      ${xLabels}
+    </svg>
+  `;
+}
+
+function renderBarGroup(containerId, groups, valueKey, formatter) {
+  const container = document.getElementById(containerId);
+  if (groups.length === 0) {
+    container.innerHTML = `<p class="card-sub">No data yet.</p>`;
+    return;
+  }
+  const max = Math.max(...groups.map((g) => g[valueKey]), 1);
+  container.innerHTML = groups
+    .slice(0, 8)
+    .map((g, i) => {
+      const pct = (g[valueKey] / max) * 100;
+      const color = CHART_COLORS[i % CHART_COLORS.length];
+      return `
+        <div class="bar-row">
+          <span class="label" title="${escapeHtml(g.key)}">${escapeHtml(g.key)}</span>
+          <div class="bar-track">
+            <div class="bar-fill" style="width:${pct.toFixed(1)}%; background:${color};"></div>
+          </div>
+          <span class="value">${escapeHtml(formatter(g))}</span>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderTopTags() {
+  const container = document.getElementById("top-tags");
+  const tags = topTags(sessions, 12);
+  if (tags.length === 0) {
+    container.innerHTML = `<p class="card-sub">Add tags when logging sessions to see them here.</p>`;
+    return;
+  }
+  container.innerHTML = tags
+    .map(
+      (t) =>
+        `<span class="tag-chip">${escapeHtml(t.tag)}<span class="count">${t.count}</span></span>`,
+    )
+    .join("");
+}
+
+function renderFilterOptions() {
+  const modelSelect = document.getElementById("filter-model");
+  const categorySelect = document.getElementById("filter-category");
+
+  const models = [...new Set(sessions.map((s) => s.model))].sort();
+  const categories = [...new Set(sessions.map((s) => s.category))].sort();
+
+  modelSelect.innerHTML =
+    `<option value="">All models</option>` +
+    models.map((m) => `<option value="${escapeHtml(m)}">${escapeHtml(m)}</option>`).join("");
+  modelSelect.value = filters.model;
+
+  categorySelect.innerHTML =
+    `<option value="">All categories</option>` +
+    categories.map((c) => `<option value="${escapeHtml(c)}">${escapeHtml(c)}</option>`).join("");
+  categorySelect.value = filters.category;
+}
+
+function renderSessionsTable() {
+  const tbody = document.getElementById("session-tbody");
+  const meta = document.getElementById("sessions-meta");
+
+  const filtered = applyFilters(sessions);
+  meta.textContent = `${filtered.length} of ${sessions.length} shown`;
+
+  if (filtered.length === 0) {
+    tbody.innerHTML = `<tr class="empty-row"><td colspan="9">No sessions match your filters yet. Log one above or click "Load sample".</td></tr>`;
+    return;
+  }
+
+  tbody.innerHTML = filtered
+    .map((s) => {
+      const date = new Date(s.timestamp);
+      const dateStr = `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+      const tokens = s.promptTokens + s.completionTokens;
+      const tagsHtml = s.tags
+        .map((t) => `<span class="tag-inline">${escapeHtml(t)}</span>`)
+        .join("");
+      return `
+        <tr data-id="${escapeHtml(s.id)}">
+          <td>${escapeHtml(dateStr)}</td>
+          <td>${escapeHtml(s.model)}</td>
+          <td>${escapeHtml(s.category)}</td>
+          <td class="num">${s.durationMinutes}</td>
+          <td class="num">${formatNumber(tokens)}</td>
+          <td class="num">${formatCost(s.cost)}</td>
+          <td class="num">${s.rating === null || s.rating === undefined ? "—" : `${s.rating}★`}</td>
+          <td class="notes-cell">${tagsHtml}${escapeHtml(s.notes)}</td>
+          <td><button class="btn btn-link" data-action="delete" data-id="${escapeHtml(s.id)}">Delete</button></td>
+        </tr>
+      `;
+    })
+    .join("");
+}
+
+function render() {
+  const now = Date.now();
+  renderSummaryCards(now);
+  renderActivityChart(now);
+  renderBarGroup("chart-models", groupByModel(sessions), "minutes", (g) => formatHours(g.minutes));
+  renderBarGroup("chart-categories", groupByCategory(sessions), "minutes", (g) =>
+    formatHours(g.minutes),
+  );
+  renderTopTags();
+  renderFilterOptions();
+  renderSessionsTable();
+}
+
+// ---------- event wiring ----------
+
+function wireForm() {
+  const form = document.getElementById("session-form");
+  const tsInput = document.getElementById("f-timestamp");
+  tsInput.value = formatDateTimeLocal(Date.now());
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const tsValue = parseDateTimeLocal(tsInput.value);
+    const timestamp = Number.isFinite(tsValue) ? tsValue : Date.now();
+
+    const duration = parseFloat(document.getElementById("f-duration").value);
+    const promptTokens = parseFloat(document.getElementById("f-prompt-tokens").value);
+    const completionTokens = parseFloat(document.getElementById("f-completion-tokens").value);
+    const cost = parseFloat(document.getElementById("f-cost").value);
+    const ratingRaw = document.getElementById("f-rating").value;
+
+    addSession({
+      timestamp,
+      model: document.getElementById("f-model").value.trim() || "unknown",
+      category: document.getElementById("f-category").value,
+      durationMinutes: Number.isFinite(duration) ? duration : 0,
+      promptTokens: Number.isFinite(promptTokens) ? promptTokens : 0,
+      completionTokens: Number.isFinite(completionTokens) ? completionTokens : 0,
+      cost: Number.isFinite(cost) ? cost : 0,
+      rating: ratingRaw === "" ? null : parseInt(ratingRaw, 10),
+      notes: document.getElementById("f-notes").value,
+      tags: parseTags(document.getElementById("f-tags").value),
+    });
+
+    // Keep the form mostly populated for rapid entry, but clear notes/tags
+    // and bump the timestamp to now so the next entry is fresh.
+    document.getElementById("f-notes").value = "";
+    document.getElementById("f-tags").value = "";
+    document.getElementById("f-prompt-tokens").value = "";
+    document.getElementById("f-completion-tokens").value = "";
+    document.getElementById("f-cost").value = "";
+    document.getElementById("f-rating").value = "";
+    tsInput.value = formatDateTimeLocal(Date.now());
+  });
+}
+
+function wireTable() {
+  document.getElementById("session-tbody").addEventListener("click", (e) => {
+    const target = e.target instanceof HTMLElement ? e.target : null;
+    if (!target) return;
+    if (target.dataset.action === "delete") {
+      const id = target.dataset.id;
+      if (id && confirm("Delete this session?")) {
+        deleteSession(id);
+      }
+    }
+  });
+}
+
+function wireFilters() {
+  document.getElementById("filter-model").addEventListener("change", (e) => {
+    filters.model = e.target.value;
+    renderSessionsTable();
+  });
+  document.getElementById("filter-category").addEventListener("change", (e) => {
+    filters.category = e.target.value;
+    renderSessionsTable();
+  });
+  document.getElementById("filter-search").addEventListener("input", (e) => {
+    filters.search = e.target.value;
+    renderSessionsTable();
+  });
+}
+
+function wireHeaderButtons() {
+  document.getElementById("btn-export").addEventListener("click", () => {
+    const blob = new Blob([JSON.stringify(sessions, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `ai-metrics-${toIsoDay(Date.now())}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  const importInput = document.getElementById("import-input");
+  document.getElementById("btn-import").addEventListener("click", () => importInput.click());
+  importInput.addEventListener("change", (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target.result);
+        if (!Array.isArray(data)) {
+          alert("Invalid file: expected a JSON array of sessions.");
+          return;
+        }
+        if (!confirm(`Import ${data.length} sessions? This will replace your current data.`)) {
+          return;
+        }
+        sessions = data.map((s) => createSession(s));
+        sessions.sort((a, b) => b.timestamp - a.timestamp);
+        saveSessions();
+        render();
+      } catch {
+        alert("Could not parse the file. Make sure it is a valid AI metrics JSON export.");
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  });
+
+  document.getElementById("btn-reset").addEventListener("click", () => {
+    if (sessions.length === 0) return;
+    if (confirm("Delete all sessions? This cannot be undone.")) {
+      sessions = [];
+      saveSessions();
+      render();
+    }
+  });
+
+  document.getElementById("btn-sample").addEventListener("click", () => {
+    if (
+      sessions.length > 0 &&
+      !confirm("This will add sample sessions to your existing data. Continue?")
+    ) {
+      return;
+    }
+    sessions = sessions.concat(buildSampleSessions());
+    sessions.sort((a, b) => b.timestamp - a.timestamp);
+    saveSessions();
+    render();
+  });
+}
+
+function buildSampleSessions() {
+  const now = Date.now();
+  const DAY = 24 * 60 * 60 * 1000;
+  const data = [
+    {
+      daysAgo: 0,
+      hour: 10,
+      model: "claude-opus-4-6",
+      category: "coding",
+      durationMinutes: 45,
+      promptTokens: 3200,
+      completionTokens: 1800,
+      cost: 0.42,
+      rating: 5,
+      notes: "Refactored metrics engine with tests",
+      tags: ["tdd", "refactor"],
+    },
+    {
+      daysAgo: 0,
+      hour: 14,
+      model: "claude-sonnet-4-6",
+      category: "writing",
+      durationMinutes: 20,
+      promptTokens: 1500,
+      completionTokens: 2400,
+      cost: 0.18,
+      rating: 4,
+      notes: "Drafted release notes",
+      tags: ["docs"],
+    },
+    {
+      daysAgo: 1,
+      hour: 9,
+      model: "claude-opus-4-6",
+      category: "analysis",
+      durationMinutes: 30,
+      promptTokens: 4100,
+      completionTokens: 2200,
+      cost: 0.51,
+      rating: 5,
+      notes: "Reviewed SQL query plan",
+      tags: ["sql", "perf"],
+    },
+    {
+      daysAgo: 1,
+      hour: 16,
+      model: "gpt-4o",
+      category: "brainstorm",
+      durationMinutes: 25,
+      promptTokens: 800,
+      completionTokens: 1500,
+      cost: 0.12,
+      rating: 3,
+      notes: "Product naming session",
+      tags: ["product"],
+    },
+    {
+      daysAgo: 2,
+      hour: 11,
+      model: "claude-opus-4-6",
+      category: "coding",
+      durationMinutes: 60,
+      promptTokens: 5500,
+      completionTokens: 3200,
+      cost: 0.71,
+      rating: 4,
+      notes: "Debugged websocket reconnection",
+      tags: ["bug", "websocket"],
+    },
+    {
+      daysAgo: 3,
+      hour: 13,
+      model: "claude-sonnet-4-6",
+      category: "research",
+      durationMinutes: 40,
+      promptTokens: 2800,
+      completionTokens: 2100,
+      cost: 0.22,
+      rating: 4,
+      notes: "Compared vector DBs",
+      tags: ["research"],
+    },
+    {
+      daysAgo: 4,
+      hour: 10,
+      model: "claude-opus-4-6",
+      category: "coding",
+      durationMinutes: 35,
+      promptTokens: 3000,
+      completionTokens: 1800,
+      cost: 0.38,
+      rating: 5,
+      notes: "Added pagination to API",
+      tags: ["api"],
+    },
+    {
+      daysAgo: 5,
+      hour: 15,
+      model: "gemini-2.5-pro",
+      category: "writing",
+      durationMinutes: 15,
+      promptTokens: 900,
+      completionTokens: 1200,
+      cost: 0.05,
+      rating: 3,
+      notes: "Email draft",
+      tags: ["email"],
+    },
+    {
+      daysAgo: 6,
+      hour: 9,
+      model: "claude-opus-4-6",
+      category: "learning",
+      durationMinutes: 50,
+      promptTokens: 2200,
+      completionTokens: 3400,
+      cost: 0.44,
+      rating: 5,
+      notes: "Deep dive into Rust lifetimes",
+      tags: ["rust", "learning"],
+    },
+    {
+      daysAgo: 8,
+      hour: 14,
+      model: "claude-sonnet-4-6",
+      category: "coding",
+      durationMinutes: 25,
+      promptTokens: 1500,
+      completionTokens: 1100,
+      cost: 0.12,
+      rating: 4,
+      notes: "CSS tweaks",
+      tags: ["css"],
+    },
+    {
+      daysAgo: 9,
+      hour: 10,
+      model: "gpt-4o",
+      category: "analysis",
+      durationMinutes: 30,
+      promptTokens: 2100,
+      completionTokens: 1300,
+      cost: 0.17,
+      rating: 3,
+      notes: "Analyzed support tickets",
+      tags: ["support"],
+    },
+    {
+      daysAgo: 10,
+      hour: 11,
+      model: "claude-opus-4-6",
+      category: "coding",
+      durationMinutes: 55,
+      promptTokens: 4000,
+      completionTokens: 2500,
+      cost: 0.57,
+      rating: 5,
+      notes: "Wrote migration script",
+      tags: ["db", "migration"],
+    },
+    {
+      daysAgo: 12,
+      hour: 16,
+      model: "claude-opus-4-6",
+      category: "research",
+      durationMinutes: 20,
+      promptTokens: 1800,
+      completionTokens: 900,
+      cost: 0.2,
+      rating: 4,
+      notes: "OAuth providers comparison",
+      tags: ["auth"],
+    },
+  ];
+  return data.map((d) =>
+    createSession({
+      ...d,
+      timestamp: now - d.daysAgo * DAY + (d.hour - 12) * 3600 * 1000,
+    }),
+  );
+}
+
+// ---------- boot ----------
+
+wireForm();
+wireTable();
+wireFilters();
+wireHeaderButtons();
+render();

--- a/apps/ai-metrics/src/metrics.js
+++ b/apps/ai-metrics/src/metrics.js
@@ -1,0 +1,222 @@
+/**
+ * AI metrics engine.
+ *
+ * Pure functions that derive aggregate statistics from a list of sessions.
+ * No DOM, no storage, no side effects — everything here is fully testable.
+ *
+ * A session records a single interaction with an AI model. The shape returned
+ * from createSession() is the canonical, normalized form the rest of the
+ * dashboard assumes.
+ */
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function numOrDefault(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function generateId() {
+  const time = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `s_${time}_${rand}`;
+}
+
+/**
+ * Normalize a partial session object into the canonical shape. Missing or
+ * invalid fields are coerced to safe defaults. Unknown numeric ratings become
+ * `null` so we can distinguish "not rated" from "rated 0".
+ */
+export function createSession(partial = {}) {
+  return {
+    id: typeof partial.id === "string" && partial.id.length > 0 ? partial.id : generateId(),
+    timestamp: numOrDefault(partial.timestamp, Date.now()),
+    model:
+      typeof partial.model === "string" && partial.model.length > 0 ? partial.model : "unknown",
+    category:
+      typeof partial.category === "string" && partial.category.length > 0
+        ? partial.category
+        : "other",
+    durationMinutes: Math.max(0, numOrDefault(partial.durationMinutes, 0)),
+    promptTokens: Math.max(0, numOrDefault(partial.promptTokens, 0)),
+    completionTokens: Math.max(0, numOrDefault(partial.completionTokens, 0)),
+    cost: Math.max(0, numOrDefault(partial.cost, 0)),
+    rating: Number.isFinite(partial.rating) ? partial.rating : null,
+    notes: typeof partial.notes === "string" ? partial.notes : "",
+    tags: Array.isArray(partial.tags) ? [...partial.tags] : [],
+  };
+}
+
+/**
+ * Format a timestamp (ms since epoch) as a UTC `YYYY-MM-DD` day key. Using
+ * UTC keeps grouping deterministic across timezones.
+ */
+export function toIsoDay(timestamp) {
+  const d = new Date(timestamp);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Reduce a list of sessions into total counters. averageRating is computed
+ * only over sessions that were explicitly rated.
+ */
+export function computeSummary(sessions) {
+  const summary = {
+    totalSessions: sessions.length,
+    totalMinutes: 0,
+    totalPromptTokens: 0,
+    totalCompletionTokens: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    averageRating: 0,
+    ratedCount: 0,
+  };
+  let ratingSum = 0;
+  for (const s of sessions) {
+    summary.totalMinutes += numOrDefault(s.durationMinutes, 0);
+    summary.totalPromptTokens += numOrDefault(s.promptTokens, 0);
+    summary.totalCompletionTokens += numOrDefault(s.completionTokens, 0);
+    summary.totalCost += numOrDefault(s.cost, 0);
+    if (Number.isFinite(s.rating)) {
+      ratingSum += s.rating;
+      summary.ratedCount += 1;
+    }
+  }
+  summary.totalTokens = summary.totalPromptTokens + summary.totalCompletionTokens;
+  summary.averageRating = summary.ratedCount > 0 ? ratingSum / summary.ratedCount : 0;
+  return summary;
+}
+
+function aggregateBy(sessions, keyFn) {
+  const map = new Map();
+  for (const s of sessions) {
+    const rawKey = keyFn(s);
+    const key = typeof rawKey === "string" && rawKey.length > 0 ? rawKey : "unknown";
+    let g = map.get(key);
+    if (!g) {
+      g = { key, count: 0, minutes: 0, tokens: 0, cost: 0, ratingSum: 0, ratedCount: 0 };
+      map.set(key, g);
+    }
+    g.count += 1;
+    g.minutes += numOrDefault(s.durationMinutes, 0);
+    g.tokens += numOrDefault(s.promptTokens, 0) + numOrDefault(s.completionTokens, 0);
+    g.cost += numOrDefault(s.cost, 0);
+    if (Number.isFinite(s.rating)) {
+      g.ratingSum += s.rating;
+      g.ratedCount += 1;
+    }
+  }
+  return [...map.values()]
+    .map((g) => ({
+      key: g.key,
+      count: g.count,
+      minutes: g.minutes,
+      tokens: g.tokens,
+      cost: g.cost,
+      averageRating: g.ratedCount > 0 ? g.ratingSum / g.ratedCount : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function groupByModel(sessions) {
+  return aggregateBy(sessions, (s) => s.model);
+}
+
+export function groupByCategory(sessions) {
+  return aggregateBy(sessions, (s) => s.category);
+}
+
+/**
+ * Aggregate sessions into per-day buckets, sorted oldest → newest.
+ */
+export function groupByDay(sessions) {
+  const map = new Map();
+  for (const s of sessions) {
+    const day = toIsoDay(s.timestamp);
+    let bucket = map.get(day);
+    if (!bucket) {
+      bucket = { day, count: 0, minutes: 0, cost: 0 };
+      map.set(day, bucket);
+    }
+    bucket.count += 1;
+    bucket.minutes += numOrDefault(s.durationMinutes, 0);
+    bucket.cost += numOrDefault(s.cost, 0);
+  }
+  return [...map.values()].sort((a, b) => a.day.localeCompare(b.day));
+}
+
+/**
+ * Count the longest run of consecutive days ending on or just before the
+ * reference date that contains at least one session. If neither today nor
+ * yesterday has a session, the streak is 0.
+ */
+export function computeStreak(sessions, referenceDate = Date.now()) {
+  if (sessions.length === 0) return 0;
+  const days = new Set(sessions.map((s) => toIsoDay(s.timestamp)));
+  const today = toIsoDay(referenceDate);
+  const yesterday = toIsoDay(referenceDate - ONE_DAY_MS);
+  if (!days.has(today) && !days.has(yesterday)) return 0;
+  let cursor = days.has(today) ? referenceDate : referenceDate - ONE_DAY_MS;
+  let streak = 0;
+  while (days.has(toIsoDay(cursor))) {
+    streak += 1;
+    cursor -= ONE_DAY_MS;
+  }
+  return streak;
+}
+
+/**
+ * Compare the trailing 7-day window ending at referenceDate to the prior
+ * 7-day window. Percent change is signed; when the previous period is zero
+ * and the current period is not, returns +100.
+ */
+export function computeWeekOverWeek(sessions, referenceDate = Date.now()) {
+  const currentStart = referenceDate - 7 * ONE_DAY_MS;
+  const previousStart = currentStart - 7 * ONE_DAY_MS;
+  const current = { count: 0, minutes: 0, cost: 0 };
+  const previous = { count: 0, minutes: 0, cost: 0 };
+  for (const s of sessions) {
+    const ts = s.timestamp;
+    const minutes = numOrDefault(s.durationMinutes, 0);
+    const cost = numOrDefault(s.cost, 0);
+    if (ts > currentStart && ts <= referenceDate) {
+      current.count += 1;
+      current.minutes += minutes;
+      current.cost += cost;
+    } else if (ts > previousStart && ts <= currentStart) {
+      previous.count += 1;
+      previous.minutes += minutes;
+      previous.cost += cost;
+    }
+  }
+  const percentChange = (curr, prev) => {
+    if (prev === 0) return curr === 0 ? 0 : 100;
+    return ((curr - prev) / prev) * 100;
+  };
+  return {
+    current,
+    previous,
+    percentChangeCount: percentChange(current.count, previous.count),
+    percentChangeMinutes: percentChange(current.minutes, previous.minutes),
+  };
+}
+
+/**
+ * Return the top `limit` most-used tags sorted by count descending.
+ */
+export function topTags(sessions, limit = 5) {
+  const counts = new Map();
+  for (const s of sessions) {
+    if (!Array.isArray(s.tags)) continue;
+    for (const tag of s.tags) {
+      if (typeof tag !== "string" || tag.length === 0) continue;
+      counts.set(tag, (counts.get(tag) || 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, limit);
+}

--- a/apps/ai-metrics/style.css
+++ b/apps/ai-metrics/style.css
@@ -1,0 +1,442 @@
+:root {
+  --bg: #0d1117;
+  --bg-elev: #161b22;
+  --bg-elev-2: #1c232c;
+  --border: #21262d;
+  --border-strong: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --text-dim: #484f58;
+  --accent: #58a6ff;
+  --accent-soft: #58a6ff33;
+  --success: #3fb950;
+  --warning: #d29922;
+  --danger: #f85149;
+  --danger-soft: #f8514933;
+  --chart-1: #58a6ff;
+  --chart-2: #a371f7;
+  --chart-3: #3fb950;
+  --chart-4: #f0883e;
+  --chart-5: #e685b5;
+  --chart-6: #79c0ff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 20px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.page-header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.page-footer {
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  text-align: center;
+  margin-top: 16px;
+}
+
+/* Buttons */
+.btn {
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    transform 0.1s;
+  font-weight: 500;
+  font-family: inherit;
+}
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn-primary {
+  background: #238636;
+  color: #fff;
+}
+.btn-primary:hover {
+  background: #2ea043;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent-soft);
+}
+.btn-secondary:hover {
+  background: #58a6ff16;
+}
+
+.btn-danger {
+  background: transparent;
+  color: var(--danger);
+  border: 1px solid var(--danger-soft);
+}
+.btn-danger:hover {
+  background: #f8514916;
+}
+
+.btn-link {
+  background: transparent;
+  color: var(--danger);
+  border: none;
+  padding: 4px 6px;
+  font-size: 0.75rem;
+}
+.btn-link:hover {
+  color: #ff6b63;
+}
+
+/* Summary cards */
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-card .label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.summary-card .value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.summary-card .delta {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.delta.up {
+  color: var(--success);
+}
+.delta.down {
+  color: var(--danger);
+}
+
+/* Cards */
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.card-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 16px;
+}
+
+/* Form */
+.session-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field.field-grow {
+  grid-column: span 2;
+}
+
+.field > span {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.field input,
+.field select,
+.field textarea {
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--text);
+  font-size: 0.85rem;
+  outline: none;
+  transition: border-color 0.15s;
+  font-family: inherit;
+}
+
+.field input:focus,
+.field select:focus {
+  border-color: var(--accent);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Activity chart (SVG) */
+.chart-container {
+  width: 100%;
+  min-height: 160px;
+}
+
+.chart-container svg {
+  width: 100%;
+  height: 180px;
+  display: block;
+}
+
+.bar-day {
+  fill: var(--chart-1);
+  opacity: 0.8;
+  transition: opacity 0.15s;
+}
+.bar-day:hover {
+  opacity: 1;
+}
+
+.axis-line {
+  stroke: var(--border-strong);
+  stroke-width: 1;
+}
+
+.axis-label {
+  fill: var(--text-dim);
+  font-size: 9px;
+}
+
+/* Horizontal bars */
+.bars-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8rem;
+}
+
+.bar-row .label {
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bar-row .bar-track {
+  height: 10px;
+  background: var(--bg);
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.bar-row .bar-fill {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 0.3s ease;
+}
+
+.bar-row .value {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+}
+
+/* Tag cloud */
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  font-size: 0.8rem;
+  color: var(--text);
+}
+.tag-chip .count {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+/* Sessions table */
+.filter-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.session-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.session-table th,
+.session-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.session-table th {
+  background: var(--bg-elev-2);
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.session-table tr:last-child td {
+  border-bottom: none;
+}
+
+.session-table td.num,
+.session-table th.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.session-table .notes-cell {
+  max-width: 220px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.session-table .tag-inline {
+  display: inline-block;
+  padding: 1px 6px;
+  margin-right: 4px;
+  font-size: 0.65rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 3px;
+}
+
+.empty-row td {
+  text-align: center;
+  color: var(--text-dim);
+  padding: 24px;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  #app {
+    padding: 16px 12px 40px;
+  }
+  .page-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .header-actions {
+    justify-content: flex-start;
+  }
+  .field.field-grow {
+    grid-column: span 1;
+  }
+}

--- a/apps/ai-metrics/vite.config.js
+++ b/apps/ai-metrics/vite.config.js
@@ -1,0 +1,7 @@
+import { resolve } from "path";
+import { createGameConfig } from "../../vite.shared.js";
+
+export default createGameConfig({
+  root: resolve(import.meta.dirname, "."),
+  port: 3010,
+});

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Claude Playground</title>
+    <meta
+      name="description"
+      content="Browser-based arcade of games and apps built with Claude Code"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main id="app">
+      <header class="hero">
+        <h1>Claude Playground</h1>
+        <p>A collection of browser games and apps, built with Claude Code.</p>
+      </header>
+
+      <section>
+        <div class="section-head">
+          <h2>Apps</h2>
+          <p>Tools and dashboards.</p>
+        </div>
+        <div class="card-grid">
+          <a class="card" href="./ai-metrics/">
+            <div class="card-icon" aria-hidden="true">📊</div>
+            <h3>AI Metrics</h3>
+            <p>Track your progress using Claude and other AI models.</p>
+          </a>
+          <a class="card" href="./timeline-tracker/">
+            <div class="card-icon" aria-hidden="true">🕒</div>
+            <h3>Timeline Tracker</h3>
+            <p>Log what happens during a work session on a live timeline.</p>
+          </a>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-head">
+          <h2>Games</h2>
+          <p>Pick your poison.</p>
+        </div>
+        <div class="card-grid">
+          <a class="card card-featured" href="./arcade-hub/">
+            <div class="card-icon" aria-hidden="true">🎮</div>
+            <h3>Arcade Hub</h3>
+            <p>Launch pad for every game in the collection.</p>
+          </a>
+          <a class="card" href="./runner/">
+            <div class="card-icon" aria-hidden="true">🏃</div>
+            <h3>Runner</h3>
+            <p>Godot 4.6 action-runner with strafing zombies.</p>
+          </a>
+          <a class="card" href="./splendor/">
+            <div class="card-icon" aria-hidden="true">💎</div>
+            <h3>Splendor</h3>
+            <p>Gem-collecting engine-builder card game.</p>
+          </a>
+          <a class="card" href="./sudoku/">
+            <div class="card-icon" aria-hidden="true">🔢</div>
+            <h3>Sudoku</h3>
+            <p>Classic 9×9 logic puzzle with four difficulty levels.</p>
+          </a>
+          <a class="card" href="./solitaire/">
+            <div class="card-icon" aria-hidden="true">🃏</div>
+            <h3>Solitaire</h3>
+            <p>Klondike solitaire in the browser.</p>
+          </a>
+          <a class="card" href="./tic-tac-toe/">
+            <div class="card-icon" aria-hidden="true">❌</div>
+            <h3>Tic-Tac-Toe</h3>
+            <p>Local and online multiplayer.</p>
+          </a>
+          <a class="card" href="./space-invaders/">
+            <div class="card-icon" aria-hidden="true">👾</div>
+            <h3>Space Invaders</h3>
+            <p>Arcade shoot-'em-up.</p>
+          </a>
+        </div>
+      </section>
+
+      <footer class="page-footer">
+        <a href="https://github.com/vi-o-al-ai/claude_playground">View source on GitHub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ai-arcade/landing",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Root GitHub Pages landing page linking to every app and game in the monorepo",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/apps/landing/style.css
+++ b/apps/landing/style.css
@@ -1,0 +1,165 @@
+:root {
+  --bg: #0f0f23;
+  --bg-elev: #1a1a2e;
+  --bg-elev-2: #252540;
+  --border: #2a2a4a;
+  --border-hover: #7b2ff7;
+  --text: #e0e0e0;
+  --text-muted: #9a9ab0;
+  --text-dim: #6b6b85;
+  --accent-a: #00d4ff;
+  --accent-b: #7b2ff7;
+  --accent-c: #ff2d95;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 1rem 2.5rem;
+  background: linear-gradient(135deg, #1a1a3e 0%, #0f0f23 100%);
+  border-bottom: 2px solid #333;
+  margin: 0 -1.5rem 3rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.08em;
+  background: linear-gradient(90deg, var(--accent-a), var(--accent-b), var(--accent-c));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero p {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+section {
+  margin-bottom: 3rem;
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-head h2 {
+  font-size: 1.3rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.section-head p {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem 1.5rem 1.75rem;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    background 0.18s ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-3px);
+  border-color: var(--border-hover);
+  background: var(--bg-elev-2);
+  box-shadow: 0 10px 24px rgba(123, 47, 247, 0.22);
+  outline: none;
+}
+
+.card-icon {
+  font-size: 2.1rem;
+  margin-bottom: 0.25rem;
+}
+
+.card h3 {
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.card p {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.card-featured {
+  background: linear-gradient(135deg, rgba(123, 47, 247, 0.18) 0%, rgba(26, 26, 46, 1) 60%);
+  border-color: rgba(123, 47, 247, 0.4);
+}
+
+.page-footer {
+  text-align: center;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+
+.page-footer a {
+  color: var(--accent-b);
+  text-decoration: none;
+}
+
+.page-footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2.5rem 1rem 2rem;
+  }
+  .card {
+    padding: 1.25rem 1.25rem 1.5rem;
+  }
+}

--- a/apps/landing/vite.config.js
+++ b/apps/landing/vite.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+// The landing page is special: its build output is copied to the GitHub
+// Pages root (_site/index.html), not into a per-package subdirectory. So
+// unlike the other packages — which nest under `/claude_playground/<name>/`
+// — this one's base is exactly `/claude_playground/` when deployed.
+const pagesBase = process.env.PAGES_BASE;
+const base = pagesBase ? `${pagesBase}/` : "/";
+
+export default defineConfig({
+  root: resolve(import.meta.dirname, "."),
+  base,
+  build: {
+    outDir: resolve(import.meta.dirname, "dist"),
+    emptyOutDir: true,
+  },
+  server: {
+    port: 3011,
+    open: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,10 @@
         "vitest": "^4.1.2"
       }
     },
+    "apps/ai-metrics": {
+      "name": "@ai-arcade/ai-metrics",
+      "version": "1.0.0"
+    },
     "apps/news-digest": {
       "name": "@ai-arcade/news-digest",
       "version": "1.0.0"
@@ -72,6 +76,10 @@
       "dependencies": {
         "@arcade/shared-ui": "*"
       }
+    },
+    "node_modules/@ai-arcade/ai-metrics": {
+      "resolved": "apps/ai-metrics",
+      "link": true
     },
     "node_modules/@ai-arcade/arcade-hub": {
       "resolved": "games/arcade-hub",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,10 @@
       "name": "@ai-arcade/ai-metrics",
       "version": "1.0.0"
     },
+    "apps/landing": {
+      "name": "@ai-arcade/landing",
+      "version": "1.0.0"
+    },
     "apps/news-digest": {
       "name": "@ai-arcade/news-digest",
       "version": "1.0.0"
@@ -83,6 +87,10 @@
     },
     "node_modules/@ai-arcade/arcade-hub": {
       "resolved": "games/arcade-hub",
+      "link": true
+    },
+    "node_modules/@ai-arcade/landing": {
+      "resolved": "apps/landing",
       "link": true
     },
     "node_modules/@ai-arcade/news-digest": {


### PR DESCRIPTION
Adds the apps/ai-metrics workspace skeleton and a full Vitest suite for
the metrics engine (createSession, computeSummary, groupByModel/Category/Day,
computeStreak, computeWeekOverWeek, topTags). Implementation lands in a
follow-up commit per the TDD workflow.