### PR TITLE
fix(news-digest): unblock cron commit and add verify step

### DIFF
--- a/apps/node/news-digest/PROMPT.md
+++ b/apps/node/news-digest/PROMPT.md
@@ -7,7 +7,7 @@ Follow these steps **in order**. Do not skip steps. Do not invent sources that a
 ## Inputs and outputs
 
 - **Config path:** `./data/sources.json` (relative to the workflow working directory)
-- **Schema (reference only):** `./engine/apps/news-digest/sources.schema.json`
+- **Schema (reference only):** `./engine/apps/node/news-digest/sources.schema.json`
 - **Output path:** `./data/digests/YYYY-MM-DD.md`, where `YYYY-MM-DD` is today's UTC date
 - **Commit message:** `digest: YYYY-MM-DD`
 - **Working directory:** the root of the private data repo (`./data` in CI), with the engine available at `./engine`
@@ -102,12 +102,11 @@ Use one blank line between sections. Do not add a table of contents, a footer, o
 
 ## Step 5: Commit and push
 
-From the `./data` directory:
+From the `./data` directory (the workflow has already configured the bot's `user.name` and `user.email`):
 
 ```bash
 git add digests/
-git -c user.name="news-digest-bot" -c user.email="news-digest-bot@users.noreply.github.com" \
-    commit -m "digest: YYYY-MM-DD" || echo "no changes to commit"
+git commit -m "digest: YYYY-MM-DD" || echo "no changes to commit"
 git push
 ```
 

--- a/apps/node/news-digest/workflow.example.yml
+++ b/apps/node/news-digest/workflow.example.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Follow the instructions in ./engine/apps/news-digest/PROMPT.md exactly.
+            Follow the instructions in ./engine/apps/node/news-digest/PROMPT.md exactly.
 
             Context:
             - Config file: ./data/sources.json
@@ -59,4 +59,19 @@ jobs:
             After writing the digest file, cd into ./data, stage digests/,
             commit with message "digest: YYYY-MM-DD", and push.
           claude_args: |
-            --allowedTools "WebFetch,Read,Write,Edit,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git pull:*),Bash(cd:*),Bash(ls:*),Bash(mkdir:*),Bash(date:*)"
+            --allowedTools "WebFetch,Read,Write,Edit,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git pull:*),Bash(git status:*),Bash(git diff:*),Bash(cd:*),Bash(ls:*),Bash(mkdir:*),Bash(date:*)"
+
+      - name: Verify digest was committed
+        working-directory: data
+        run: |
+          TODAY=$(date -u +%F)
+          if [ ! -f "digests/$TODAY.md" ]; then
+            echo "::error::No digest file at digests/$TODAY.md — the agent did not produce today's digest."
+            exit 1
+          fi
+          if ! git log -1 --pretty=%s | grep -q "^digest: $TODAY$"; then
+            echo "::error::Latest commit is not 'digest: $TODAY'. The digest file exists but was not committed."
+            git log -1 --pretty=fuller
+            exit 1
+          fi
+          echo "OK: digests/$TODAY.md committed."


### PR DESCRIPTION
## Summary
- Drop the `git -c user.name=... -c user.email=...` flags in `PROMPT.md` step 5 — they made the agent's commit fail the workflow's `--allowedTools` matcher (`Bash(git commit:*)`), so the cron has been silently producing no digest. Bot identity is already set by the workflow's `Configure git for bot commits` step.
- Broaden `workflow.example.yml` allowlist with `Bash(git status:*),Bash(git diff:*)` and add a `Verify digest was committed` step that fails the job if today's `digests/YYYY-MM-DD.md` is missing or wasn't committed.
- Fix path drift in `PROMPT.md` and `workflow.example.yml` (`./engine/apps/news-digest/...` → `./engine/apps/node/news-digest/...`) left over from the monorepo restructure.

Closes #86.

## Test plan
- [x] `npm run check` passes (lint + Prettier + 195 Vitest tests).
- [ ] After merge, mirror the allowlist/verify-step changes into `vi-o-al-ai/news-digest`'s `.github/workflows/daily.yml` (separate PR).
- [ ] Trigger `gh workflow run daily.yml -R vi-o-al-ai/news-digest` and confirm a `digest: YYYY-MM-DD` commit lands and the new verify step prints `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)