### PR TITLE
feat(news-digest): prefetch Reddit + tighten agent allowlist

### DIFF
--- a/apps/node/news-digest/PROMPT.md
+++ b/apps/node/news-digest/PROMPT.md
@@ -37,9 +37,10 @@ Process sources **in the order they appear in the config**. For each source, use
 
 ### Type: `reddit`
 
-- **URL:** `https://www.reddit.com/r/{subreddit}/top.json?limit={topN}&t={timeWindow}`
-  - `timeWindow` defaults to `day` if unset
-- **Request requirement:** Reddit blocks default `User-Agent` strings. If `WebFetch` allows header customization in this environment, send `User-Agent: news-digest-bot/1.0 (github.com/vi-o-al-ai/claude_playground)`. If not, attempt the fetch anyway — Reddit sometimes responds to tool-based user agents.
+Reddit blocks Claude's `WebFetch` User-Agent and rate-limits GitHub Actions runner IPs hard, so the workflow **pre-fetches** Reddit JSON in a shell step (with a polite UA + retry) before the agent runs. The agent reads the cached JSON from disk — **do not call `WebFetch` on Reddit URLs**, it will return 403.
+
+- **Source:** `./data/.fetched/reddit/{subreddit}.json` — read with the `Read` tool.
+- **If the file is missing** for a configured Reddit source, the pre-fetch failed for that subreddit. Per the error-handling table below, emit a section heading with a one-line "no items available today" note and continue.
 - **Extract for each post** (`data.children[].data`):
   - `title` (post title)
   - `url` (the outbound article URL — may equal the Reddit permalink for self posts)
@@ -107,10 +108,10 @@ The data repo is checked out at `./data`. Run each git command as a **separate B
 Issue these three Bash calls in order:
 
 1. `git -C ./data add digests/`
-2. `git -C ./data commit -m "digest: YYYY-MM-DD" || echo "no changes to commit"`
+2. `git -C ./data commit -m "digest: YYYY-MM-DD"`
 3. `git -C ./data push`
 
-If there are no changes (the file is byte-identical to yesterday's run, which should be rare), the commit is skipped and the workflow still succeeds.
+If the commit step fails because the file is byte-identical to yesterday's digest (rare), the workflow's verification step will fail the job — that is the desired behavior. Don't try to suppress the commit error.
 
 ## Error handling summary
 

--- a/apps/node/news-digest/workflow.example.yml
+++ b/apps/node/news-digest/workflow.example.yml
@@ -43,6 +43,38 @@ jobs:
           git config user.name "news-digest-bot"
           git config user.email "news-digest-bot@users.noreply.github.com"
 
+      # Reddit blocks Claude's WebFetch UA and rate-limits the GitHub Actions IP pool.
+      # Pre-fetch each reddit source from a shell step with a polite UA so the agent
+      # can read the JSON from disk via the Read tool. HN doesn't have this problem.
+      - name: Pre-fetch Reddit sources
+        working-directory: data
+        run: |
+          set -uo pipefail
+          mkdir -p .fetched/reddit
+          UA="news-digest-bot/1.0 (+https://github.com/${{ github.repository }})"
+          DEFAULT_TOPN=$(jq -r '.topN // 5' sources.json)
+          jq -c '.sources[] | select(.type == "reddit")' sources.json | while read -r src; do
+            sub=$(echo "$src"     | jq -r '.subreddit')
+            window=$(echo "$src"  | jq -r '.timeWindow // "day"')
+            topn=$(echo "$src"    | jq -r ".topN // $DEFAULT_TOPN")
+            url="https://www.reddit.com/r/${sub}/top.json?limit=${topn}&t=${window}"
+            echo "Fetching r/${sub} (topN=${topn}, window=${window})"
+            for attempt in 1 2; do
+              if curl -sSfL -m 30 -H "User-Agent: $UA" "$url" -o ".fetched/reddit/${sub}.json"; then
+                echo "  → success (attempt $attempt)"
+                break
+              fi
+              if [ "$attempt" = "1" ]; then
+                echo "  → attempt 1 failed, retrying in 30s"
+                sleep 30
+              else
+                echo "::warning::Failed to fetch r/${sub} after retries; digest will note 'no items available today'"
+                rm -f ".fetched/reddit/${sub}.json"
+              fi
+            done
+          done
+          ls -la .fetched/reddit/ || true
+
       - name: Run Claude Code to generate digest
         uses: anthropics/claude-code-action@v1
         with:
@@ -52,14 +84,15 @@ jobs:
 
             Context:
             - Config file: ./data/sources.json
+            - Pre-fetched Reddit JSON: ./data/.fetched/reddit/{subreddit}.json (read with Read tool)
             - Output directory: ./data/digests/
             - Filename: YYYY-MM-DD.md where the date is today in UTC
             - Working directory for git operations: ./data
 
-            After writing the digest file, cd into ./data, stage digests/,
-            commit with message "digest: YYYY-MM-DD", and push.
+            Stage, commit, and push using `git -C ./data <subcommand>` as separate
+            Bash calls (`cd ./data && git ...` is blocked by a safety check).
           claude_args: |
-            --allowedTools "WebFetch,Read,Write,Edit,Bash(git -C:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git pull:*),Bash(git status:*),Bash(git diff:*),Bash(cd:*),Bash(ls:*),Bash(mkdir:*),Bash(date:*)"
+            --allowedTools "WebFetch,Read,Write,Edit,Bash(git -C ./data add:*),Bash(git -C ./data commit:*),Bash(git -C ./data push:*),Bash(git -C ./data pull:*),Bash(git -C ./data status:*),Bash(git -C ./data diff:*),Bash(ls:*),Bash(mkdir:*),Bash(date:*)"
 
       - name: Verify digest was committed
         working-directory: data


### PR DESCRIPTION
## Summary
Two coupled hardening changes for the news-digest engine.

**Reddit prefetch.** The post-#88 cron run lands a commit, but Reddit sections show "no items available today" because Reddit blocks Claude's `WebFetch` User-Agent and rate-limits the shared GitHub Actions IP pool. Move the Reddit fetch out of the agent and into a deterministic shell step that:
- iterates Reddit sources from `sources.json` via `jq`
- `curl`s each with a polite UA (`news-digest-bot/1.0 (+https://github.com/{owner}/{repo})`)
- single retry on failure with 30s backoff
- writes JSON to `./data/.fetched/reddit/{subreddit}.json`
- the agent reads from disk via `Read` (no WebFetch for Reddit)

HN keeps using `WebFetch` (Firebase, no UA block).

**Tighter allowlist.** `Bash(git -C:*)` is broad enough that an injected instruction in a fetched article could direct the agent to repoint the remote (`git -C ./data remote set-url origin <evil>`) and push the private repo elsewhere. Replace with subcommand-scoped patterns:

\`\`\`
Bash(git -C ./data add:*),    Bash(git -C ./data commit:*),
Bash(git -C ./data push:*),   Bash(git -C ./data pull:*),
Bash(git -C ./data status:*), Bash(git -C ./data diff:*)
\`\`\`

Also drops `|| echo "no changes to commit"` from PROMPT.md step 5 — `echo` isn't in the tightened allowlist and the verify step is the proper place to surface a missing commit.

Closes #89.

## Test plan
- [x] `npm run check` passes (lint + format + 195 Vitest tests).
- [ ] Mirror in `vi-o-al-ai/news-digest`'s deployed `daily.yml` (separate PR).
- [ ] Trigger manual cron, confirm: (a) `.fetched/reddit/*.json` files populated, (b) Reddit sections in digest have real items, (c) verify step passes, (d) `digest: YYYY-MM-DD` commit lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)