### PR TITLE
feat(news-digest): pivot Reddit fetcher from JSON to RSS

### DIFF
--- a/apps/node/news-digest/PROMPT.md
+++ b/apps/node/news-digest/PROMPT.md
@@ -37,17 +37,19 @@ Process sources **in the order they appear in the config**. For each source, use
 
 ### Type: `reddit`
 
-Reddit blocks Claude's `WebFetch` User-Agent and rate-limits GitHub Actions runner IPs hard, so the workflow **pre-fetches** Reddit JSON in a shell step (with a polite UA + retry) before the agent runs. The agent reads the cached JSON from disk — **do not call `WebFetch` on Reddit URLs**, it will return 403.
+Reddit gated the anonymous `.json` API in late 2025 (403 to all anonymous clients regardless of IP/UA), but the RSS/Atom feed at `/r/{sub}/top.rss` is still ungated. The workflow **pre-fetches** the Atom XML in a shell step (with a polite UA + retry) before the agent runs. The agent reads the cached XML from disk — **do not call `WebFetch` on Reddit URLs**, it will return 403.
 
-- **Source:** `./data/.fetched/reddit/{subreddit}.json` — read with the `Read` tool.
+- **Source:** `./data/.fetched/reddit/{subreddit}.xml` — read with the `Read` tool.
 - **If the file is missing** for a configured Reddit source, the pre-fetch failed for that subreddit. Per the error-handling table below, emit a section heading with a one-line "no items available today" note and continue.
-- **Extract for each post** (`data.children[].data`):
-  - `title` (post title)
-  - `url` (the outbound article URL — may equal the Reddit permalink for self posts)
-  - `permalink` (Reddit comment thread path; prepend `https://reddit.com` for a full URL)
-  - `selftext` (body of self posts, may be empty)
-  - `score`, `num_comments` (optional, for display)
-  - `is_self` (true if it's a text post with no outbound link)
+- **Format:** Atom XML. Each post is an `<entry>` element. Per entry, extract:
+  - **Title:** inner text of `<title>`.
+  - **Comment thread URL:** entry-level `<link href="…">` (Reddit's comments page for the post).
+  - **Author:** `<author><name>` (e.g. `/u/jkmonger`).
+  - **Published time:** `<published>` (ISO timestamp; available, not always rendered).
+  - **Outbound article URL:** parse from the HTML-escaped `<content type="html">`. Find the `<a href="…">[link]</a>` anchor and read its `href`.
+  - **Self-post detection:** if the outbound URL's host is `reddit.com` (or it equals the entry's `<link href>`), treat it as a self-post.
+  - **Self-post body** (when present): the markdown body appears inside `<div class="md">…</div>` within `<content>`. Strip HTML tags before using it as summary input.
+- **Not available in RSS:** `score`, `num_comments`. Omit those from the bullet.
 - **Section heading:** use the source's `label` if set, otherwise `r/{subreddit}`.
 
 ### Type: `hackernews`
@@ -96,8 +98,8 @@ Emit the output file at `./data/digests/YYYY-MM-DD.md` with this exact structure
 
 **Link conventions:**
 
-- **Primary link** (on the bolded title): the outbound article URL. For Reddit self-posts where `is_self` is true or there is no outbound URL, use the full permalink URL instead. For HN text posts (no `url`), use the HN thread URL as the primary link.
-- **Secondary link** (labeled "Discussion" or "HN thread"): the comment thread — `https://reddit.com{permalink}` for Reddit, `https://news.ycombinator.com/item?id={id}` for Hacker News. Omit the secondary link only if it would duplicate the primary link.
+- **Primary link** (on the bolded title): the outbound article URL. For Reddit self-posts (outbound URL host is `reddit.com`), use the comment-thread URL as the primary link instead. For HN text posts (no `url`), use the HN thread URL as the primary link.
+- **Secondary link** (labeled "Discussion" or "HN thread"): the comment thread — the entry-level `<link href>` for Reddit, `https://news.ycombinator.com/item?id={id}` for Hacker News. Omit the secondary link only if it would duplicate the primary link.
 
 Use one blank line between sections. Do not add a table of contents, a footer, or any other boilerplate.
 

--- a/apps/node/news-digest/workflow.example.yml
+++ b/apps/node/news-digest/workflow.example.yml
@@ -43,9 +43,10 @@ jobs:
           git config user.name "news-digest-bot"
           git config user.email "news-digest-bot@users.noreply.github.com"
 
-      # Reddit blocks Claude's WebFetch UA and rate-limits the GitHub Actions IP pool.
-      # Pre-fetch each reddit source from a shell step with a polite UA so the agent
-      # can read the JSON from disk via the Read tool. HN doesn't have this problem.
+      # Reddit gated the anonymous .json API in late 2025 (403 to all anonymous
+      # clients regardless of IP/UA). The RSS feed at /r/{sub}/top.rss is still
+      # ungated, so pre-fetch the Atom XML in a shell step with a polite UA and
+      # let the agent read it from disk. HN doesn't have this problem.
       - name: Pre-fetch Reddit sources
         working-directory: data
         run: |
@@ -57,10 +58,10 @@ jobs:
             sub=$(echo "$src"     | jq -r '.subreddit')
             window=$(echo "$src"  | jq -r '.timeWindow // "day"')
             topn=$(echo "$src"    | jq -r ".topN // $DEFAULT_TOPN")
-            url="https://www.reddit.com/r/${sub}/top.json?limit=${topn}&t=${window}"
+            url="https://www.reddit.com/r/${sub}/top.rss?limit=${topn}&t=${window}"
             echo "Fetching r/${sub} (topN=${topn}, window=${window})"
             for attempt in 1 2; do
-              if curl -sSfL -m 30 -H "User-Agent: $UA" "$url" -o ".fetched/reddit/${sub}.json"; then
+              if curl -sSfL -m 30 -H "User-Agent: $UA" "$url" -o ".fetched/reddit/${sub}.xml"; then
                 echo "  → success (attempt $attempt)"
                 break
               fi
@@ -69,7 +70,7 @@ jobs:
                 sleep 30
               else
                 echo "::warning::Failed to fetch r/${sub} after retries; digest will note 'no items available today'"
-                rm -f ".fetched/reddit/${sub}.json"
+                rm -f ".fetched/reddit/${sub}.xml"
               fi
             done
           done
@@ -84,7 +85,7 @@ jobs:
 
             Context:
             - Config file: ./data/sources.json
-            - Pre-fetched Reddit JSON: ./data/.fetched/reddit/{subreddit}.json (read with Read tool)
+            - Pre-fetched Reddit Atom XML: ./data/.fetched/reddit/{subreddit}.xml (read with Read tool)
             - Output directory: ./data/digests/
             - Filename: YYYY-MM-DD.md where the date is today in UTC
             - Working directory for git operations: ./data


### PR DESCRIPTION
## Summary
Reddit gated the anonymous `.json` API in late 2025 — `top.json` returns `403` to all anonymous clients regardless of IP, UA, headers, or HTTP version. Confirmed by browser test (logged-in works, incognito 403s) and by direct curl from both residential and GH Actions IPs. The RSS feed at `/r/{sub}/top.rss` is still ungated; probe PR vi-o-al-ai/news-digest#5 confirms it's reachable from GH Actions runners.

**Changes:**
- `PROMPT.md` "Type: reddit" section: rewrite for Atom XML extraction (find outbound URL inside HTML-escaped `<content>`, detect self-posts via outbound-host check, note that `score`/`num_comments` aren't available in RSS).
- `PROMPT.md` "Link conventions": update self-post detection rule + secondary-link source.
- `workflow.example.yml` prefetch step: swap `.json` → `.rss` URL and `.json` → `.xml` output extension. Update the agent prompt's context blurb.

**Local agent simulation result:** ran the proposed prompt against locally-fetched RSS for both `r/programming` and `r/MachineLearning`. The agent extracted 8 entries cleanly across the two feeds, correctly identified self-posts, and collapsed primary/discussion links per spec.

Closes #91. Matching private-side change: vi-o-al-ai/news-digest (separate PR).

## Test plan
- [x] `npm run check` passes.
- [x] Subagent simulation against real RSS produces correct bullet output.
- [x] L2 probe: GH Actions can reach RSS endpoint (vi-o-al-ai/news-digest#5 — both subreddits returned 200).
- [ ] After merge: mirror change in private `daily.yml`.
- [ ] Trigger production cron; confirm Reddit items land in next digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)