### PR TITLE
news-digest: add generic `rss` source type

### DIFF
--- a/apps/node/news-digest/PROMPT.md
+++ b/apps/node/news-digest/PROMPT.md
@@ -21,7 +21,7 @@ Read `./data/sources.json`. Validate that:
 
 1. It is valid JSON
 2. It has a non-empty `sources` array
-3. Each source has a `type` that is either `reddit` or `hackernews`
+3. Each source has a `type` that is one of `reddit`, `hackernews`, or `rss`
 
 If any validation fails, abort with a clear error message and do not commit.
 
@@ -74,6 +74,26 @@ Reddit gated the anonymous `.json` API in late 2025 (403 to all anonymous client
   - `text` (present on Ask HN / Show HN / text posts)
 - **Section heading:** use the source's `label` if set, otherwise `Hacker News ({list})`.
 
+### Type: `rss`
+
+A generic RSS 2.0 / Atom feed (blogs, news sites, release feeds). Unlike Reddit, public feeds are not gated — fetch the feed directly.
+
+- **Fetch:** call `WebFetch` on the source's `url`. If the fetch fails or the body is not a feed (HTML, 404, empty), per the error-handling table emit a section heading with a one-line "no items available today" note and continue.
+- **Format:** detect RSS 2.0 vs Atom by the root element:
+  - **RSS 2.0** — items are `<item>` under `<channel>`. The feed title is `<channel><title>`.
+  - **Atom** — items are `<entry>` under `<feed>`. The feed title is the top-level `<feed><title>`.
+- **Item order:** feeds are conventionally newest-first. Take the first `topN` items **as they appear**; do not re-sort.
+- **Per item, extract:**
+  - **Title:** inner text of `<title>`.
+  - **Article URL (primary link):**
+    - RSS: inner text of `<link>`.
+    - Atom: the `href` of `<link rel="alternate">`; if no `rel` is present, use the first `<link href>`.
+  - **Author** (optional, omit if absent): RSS `<author>` or `<dc:creator>`; Atom `<author><name>`.
+  - **Published time:** RSS `<pubDate>` (RFC 822, e.g. `Thu, 28 May 2026 18:18:43 +0000`); Atom `<published>`, falling back to `<updated>` (ISO 8601). Used for the relative-time field, see Step 4.
+  - **Summary input** (for Step 3 fallback): RSS `<description>` or `<content:encoded>`; Atom `<summary>` or `<content>`. These usually contain HTML — strip tags before use.
+- **No comment thread:** RSS feeds have no discussion page. Omit the secondary "Discussion" link entirely.
+- **Section heading:** use the source's `label` if set, otherwise the feed's own title (`<channel><title>` for RSS, `<feed><title>` for Atom).
+
 ## Step 3: Summarize each item
 
 For each item you fetched, write a **1–2 sentence neutral summary** (no editorializing, no marketing language, no exclamation points).
@@ -105,12 +125,12 @@ Emit the output file at `./data/digests/YYYY-MM-DD.md` with this exact structure
 
 **Link conventions:**
 
-- **Primary link** (on the bolded title): the outbound article URL. For Reddit self-posts (decided by the procedure in the Reddit section above), use the comment-thread URL as the primary link instead. For HN text posts (no `url`), use the HN thread URL as the primary link.
-- **Secondary link** (labeled "Discussion" or "HN thread"): the comment thread — the entry-level `<link href>` for Reddit, `https://news.ycombinator.com/item?id={id}` for Hacker News. Omit the secondary link only if it would duplicate the primary link.
+- **Primary link** (on the bolded title): the outbound article URL. For Reddit self-posts (decided by the procedure in the Reddit section above), use the comment-thread URL as the primary link instead. For HN text posts (no `url`), use the HN thread URL as the primary link. For `rss` items, the item's article URL.
+- **Secondary link** (labeled "Discussion" or "HN thread"): the comment thread — the entry-level `<link href>` for Reddit, `https://news.ycombinator.com/item?id={id}` for Hacker News. `rss` items have no comment thread, so they have no secondary link. Omit the secondary link only if it would duplicate the primary link (or, for `rss`, always).
 
 **Posted-time field** (the `*(Xh ago)*` italic at the end of each bullet):
 
-- Source: `<published>` for Reddit (ISO 8601), `time` (Unix epoch seconds) for HN.
+- Source: `<published>` for Reddit (ISO 8601), `time` (Unix epoch seconds) for HN, `<pubDate>`/`<published>`/`<updated>` for `rss` (RFC 822 or ISO 8601).
 - Compute the elapsed time between the post's published time and the current UTC time (use the `date` Bash tool if you need to confirm "now").
 - Format:
   - Under 1 hour → `(just now)`

--- a/apps/node/news-digest/sources.example.json
+++ b/apps/node/news-digest/sources.example.json
@@ -17,6 +17,12 @@
     {
       "type": "hackernews",
       "list": "topstories"
+    },
+    {
+      "type": "rss",
+      "url": "https://github.blog/feed/",
+      "label": "GitHub Blog",
+      "topN": 3
     }
   ]
 }

--- a/apps/node/news-digest/sources.schema.json
+++ b/apps/node/news-digest/sources.schema.json
@@ -26,7 +26,8 @@
       "items": {
         "oneOf": [
           { "$ref": "#/definitions/redditSource" },
-          { "$ref": "#/definitions/hackernewsSource" }
+          { "$ref": "#/definitions/hackernewsSource" },
+          { "$ref": "#/definitions/rssSource" }
         ]
       }
     }
@@ -80,6 +81,29 @@
         "label": {
           "type": "string",
           "description": "Optional display label for the section heading. Defaults to 'Hacker News ({list})'."
+        }
+      }
+    },
+    "rssSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url"],
+      "properties": {
+        "type": { "const": "rss" },
+        "url": {
+          "type": "string",
+          "description": "Absolute URL of an RSS 2.0 or Atom feed.",
+          "format": "uri",
+          "pattern": "^https?://"
+        },
+        "topN": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional display label for the section heading. Defaults to the feed's own title."
         }
       }
     }

--- a/apps/node/news-digest/src/__tests__/config.test.js
+++ b/apps/node/news-digest/src/__tests__/config.test.js
@@ -9,7 +9,7 @@ const appRoot = resolve(here, "../..");
 const exampleConfig = JSON.parse(readFileSync(resolve(appRoot, "sources.example.json"), "utf8"));
 const schema = JSON.parse(readFileSync(resolve(appRoot, "sources.schema.json"), "utf8"));
 
-const SUPPORTED_TYPES = new Set(["reddit", "hackernews"]);
+const SUPPORTED_TYPES = new Set(["reddit", "hackernews", "rss"]);
 const REDDIT_TIME_WINDOWS = new Set(["hour", "day", "week", "month", "year", "all"]);
 const HN_LISTS = new Set(["topstories", "newstories", "beststories"]);
 
@@ -21,9 +21,10 @@ describe("sources.schema.json", () => {
     expect(schema.required).toContain("sources");
   });
 
-  it("defines the reddit and hackernews source variants", () => {
+  it("defines the reddit, hackernews, and rss source variants", () => {
     expect(schema.definitions.redditSource).toBeDefined();
     expect(schema.definitions.hackernewsSource).toBeDefined();
+    expect(schema.definitions.rssSource).toBeDefined();
   });
 });
 
@@ -56,6 +57,14 @@ describe("sources.example.json", () => {
       if (source.list !== undefined) {
         expect(HN_LISTS.has(source.list)).toBe(true);
       }
+    }
+  });
+
+  it("has valid rss sources when present", () => {
+    const rss = exampleConfig.sources.filter((s) => s.type === "rss");
+    for (const source of rss) {
+      expect(typeof source.url).toBe("string");
+      expect(source.url).toMatch(/^https?:\/\//);
     }
   });
 


### PR DESCRIPTION
Closes #94.

Adds an `rss` source variant to the news-digest engine so blog/news feeds (RSS 2.0 or Atom) can be configured alongside `reddit` and `hackernews`. Per PROMPT.md's "Extending with new source types" recipe, this is **prompt-only** — no engine code changes; the next scheduled run picks up the type automatically.

## Changes
- **`sources.schema.json`** — `rssSource` definition: `type: "rss"`, required `url` (http(s)), optional `topN`/`label`.
- **`PROMPT.md`** — new `### Type: rss` section (RSS 2.0 vs Atom detection, per-item field extraction, no comment/discussion link), plus Step 1 validation and Step 4 time/link conventions updated.
- **`sources.example.json`** — GitHub Blog example entry.
- **`src/__tests__/config.test.js`** — recognizes `rss`, asserts the schema variant, validates rss sources.

## Validation
- `npx vitest run apps/node/news-digest/src/__tests__/config.test.js` → 8/8 pass
- prettier + eslint clean
- Companion data-repo PR adds GitHub Blog + OpenAI News feeds (both verified to return current items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)